### PR TITLE
Performance reporting + insights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,12 @@ modules are thin typed wrappers over `LinkedInClient.request()`.
   the conversion's current `campaigns`, append, and `$set` the full list — never drop
   existing associations. Update endpoint: `POST /conversions/{id}?account=<urn>` with
   `X-RestLi-Method: PARTIAL_UPDATE`.
+- **Analytics:** use the `q=analytics` finder with `pivot=` (ACCOUNT|CAMPAIGN_GROUP|CAMPAIGN|
+  CREATIVE), a `dateRange=(start:(year:..,month:..,day:..),end:(..))`, `timeGranularity`
+  (ALL|DAILY|MONTHLY — no native WEEKLY, so bucket daily in code), and a filter
+  `accounts|campaignGroups|campaigns|creatives=List(<encoded urns>)`. All restli-encoded, so it
+  goes through the client's `rawQuery`. `costInUsd` is a string; metric field names are verified
+  in `analytics.ts` DEFAULT_METRIC_FIELDS. Derived KPIs + flags live in `report.ts`.
 - **Non-transactional orchestrator:** `launchFromBrief` creates a campaign group before the
   campaign; a later failure can orphan the group. (Cleanup-on-failure is implemented for
   audience upload; campaign-group cleanup is a known TODO.)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Manager.
 
 > Unofficial and not affiliated with or endorsed by LinkedIn.
 
-> Performance-insight reporting is on the roadmap. This release covers creation, matched
-> audiences (including building one straight from Salesforce), and conversion selection.
+> Covers creation, matched audiences (including building one straight from Salesforce),
+> conversion selection, and performance reporting/insights. Salesforce↔LinkedIn outcome
+> cross-reference is next on the roadmap.
 
 ## Hierarchy mapping (LinkedIn differs from Google/Meta)
 
@@ -88,6 +89,9 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
   fall back to `defaultConversionName` from config.
 - **Campaigns:** `create_campaign_group`, `create_campaign`, `create_text_ad`, `create_image_ad`
 - **Orchestrator:** `launch_from_brief` (audience + group + campaign + draft creatives in one call)
+- **Reporting:** `performance_summary` (account rollup + top/bottom + flags), `get_performance`
+  (per-entity KPIs at any level), `performance_trend` (weekly/monthly with deltas). KPIs: CTR,
+  CPC, CPM, CPL, conversion rate, cost per conversion. Levels: campaign_group → campaign → creative.
 
 ### Targeting spec
 
@@ -113,8 +117,13 @@ liam audience upload -n <name> -f <csv> # CSV of emails -> matched-audience segm
 liam audience from-salesforce -n <name> -q "<SOQL>"   # Salesforce query -> matched audience
 liam audience status <segmentId>        # matching status + resolved size
 liam conversions list                   # account conversions (pick one to track)
+liam report summary [-p <period>]       # account rollup: totals, top performers, flags
+liam report perf <level> [--parent <id>] # per-entity KPI rows
+liam report trend <level> <id> [-b weekly|monthly]  # trend with deltas
 liam launch --brief <brief.json>        # audience + group + campaign + draft creatives
 ```
+
+Periods: `last_7_days`, `last_30_days`, `last_90_days`, `month_to_date`, `last_month`.
 
 `--account` defaults to `defaultAccountId` from config where applicable.
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,10 @@ import {
   estimateAudience,
   audienceFromSalesforce,
   listConversions,
+  performanceSummary,
+  getPerformance,
+  performanceTrend,
+  resolveDateRange,
 } from "@liads/core";
 
 const program = new Command();
@@ -128,6 +132,53 @@ conversions
     const acct = opts.account ?? (await requireDefaultAccountId());
     const list = await listConversions(liads.client, acct);
     for (const c of list) console.log(`${c.id}\t${c.enabled ? "on " : "off"}\t${c.type}\t${c.name}`);
+  });
+
+const pctf = (x: number) => `${(x * 100).toFixed(2)}%`;
+const report = program.command("report").description("Performance reporting and insights");
+report
+  .command("summary")
+  .description("Account rollup: totals, top/bottom performers, flags")
+  .option("-a, --account <id>", "Ad account id (defaults to config)")
+  .option("-p, --period <period>", "last_7_days|last_30_days|last_90_days|month_to_date|last_month", "last_30_days")
+  .action(async (opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const s = await performanceSummary(liads.client, { accountId, dateRange: resolveDateRange({ period: opts.period }) });
+    const t = s.totals;
+    console.log(`TOTALS  spend $${t.costUsd}  impr ${t.impressions}  clicks ${t.clicks}  CTR ${pctf(t.ctr)}  conv ${t.conversions}  CPL/conv $${t.costPerConversion}`);
+    console.log("\nTop campaigns by spend:");
+    for (const g of s.topBySpend) console.log(`  $${g.costUsd}\tCTR ${pctf(g.ctr)}\tconv ${g.conversions}\t${g.name ?? g.entityId}`);
+    if (s.flags.length) {
+      console.log("\nFlags:");
+      for (const f of s.flags) console.log(`  [${f.kind}] ${f.name ?? f.entityUrn}: ${f.detail}`);
+    }
+  });
+report
+  .command("perf <level>")
+  .description("Per-entity rows (account|campaign_group|campaign|creative)")
+  .option("-a, --account <id>", "Ad account id (defaults to config)")
+  .option("--parent <id>", "Parent group id (campaigns) or campaign id (creatives)")
+  .option("-p, --period <period>", "Date period", "last_30_days")
+  .action(async (level, opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const rows = await getPerformance(liads.client, { accountId, level, parentId: opts.parent, dateRange: resolveDateRange({ period: opts.period }) });
+    for (const r of rows) console.log(`$${r.costUsd}\timpr ${r.impressions}\tCTR ${pctf(r.ctr)}\tCPC $${r.cpc}\tconv ${r.conversions}\t${r.name ?? r.entityId}`);
+  });
+report
+  .command("trend <level> <entityId>")
+  .description("Weekly or monthly trend with deltas")
+  .option("-b, --bucket <bucket>", "weekly|monthly", "weekly")
+  .option("-p, --period <period>", "Date period", "last_90_days")
+  .action(async (level, entityId, opts) => {
+    const liads = await createLiads();
+    const points = await performanceTrend(liads.client, { level, entityId, bucket: opts.bucket, dateRange: resolveDateRange({ period: opts.period }) });
+    for (const p of points) {
+      const dc = p.deltas?.costUsd;
+      const d = dc !== undefined ? ` (spend ${dc >= 0 ? "+" : ""}${pctf(dc)})` : "";
+      console.log(`${p.periodStart}\t$${p.costUsd}\timpr ${p.impressions}\tCTR ${pctf(p.ctr)}\tconv ${p.conversions}${d}`);
+    }
   });
 
 program

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,8 @@ export * from "./resources/conversions.js";
 export * from "./audience.js";
 export * from "./creative.js";
 export * from "./orchestrate.js";
+export * from "./resources/analytics.js";
+export * from "./report.js";
 
 // Salesforce reader (Phase 3 foundation)
 export * from "./salesforce.js";

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,0 +1,332 @@
+import type { LinkedInClient } from "./http.js";
+import {
+  fetchAnalytics,
+  type AnalyticsPivot,
+  type DateRange,
+  type LiDate,
+  type RawAnalyticsRow,
+} from "./resources/analytics.js";
+import { getCampaign } from "./resources/campaigns.js";
+import { getCampaignGroup } from "./resources/campaignGroups.js";
+
+/* ----------------------------------- dates ---------------------------------- */
+
+export type Period = "last_7_days" | "last_30_days" | "last_90_days" | "month_to_date" | "last_month";
+
+const toLiDate = (d: Date): LiDate => ({ year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() });
+const utc = (y: number, m: number, d: number) => new Date(Date.UTC(y, m, d));
+
+/** Resolve a named period into a concrete date range, relative to `now`. */
+export function resolvePeriod(period: Period, now = new Date()): DateRange {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  const today = utc(y, m, now.getUTCDate());
+  const back = (n: number) => {
+    const s = new Date(today);
+    s.setUTCDate(s.getUTCDate() - (n - 1));
+    return { start: toLiDate(s), end: toLiDate(today) };
+  };
+  switch (period) {
+    case "last_7_days": return back(7);
+    case "last_30_days": return back(30);
+    case "last_90_days": return back(90);
+    case "month_to_date": return { start: toLiDate(utc(y, m, 1)), end: toLiDate(today) };
+    case "last_month": return { start: toLiDate(utc(y, m - 1, 1)), end: toLiDate(utc(y, m, 0)) };
+  }
+}
+
+/** Parse "YYYY-MM-DD" into a LiDate. */
+export function parseDate(s: string): LiDate {
+  const [year, month, day] = s.split("-").map(Number);
+  return { year: year!, month: month!, day: day! };
+}
+
+/** Resolve a date range from an explicit start/end (YYYY-MM-DD) or a named period. */
+export function resolveDateRange(opts: { period?: Period; startDate?: string; endDate?: string }): DateRange {
+  if (opts.startDate && opts.endDate) {
+    return { start: parseDate(opts.startDate), end: parseDate(opts.endDate) };
+  }
+  return resolvePeriod(opts.period ?? "last_30_days");
+}
+
+/* --------------------------------- metrics ---------------------------------- */
+
+export interface MetricRow {
+  entityUrn: string;
+  entityId: string;
+  name?: string;
+  impressions: number;
+  clicks: number;
+  costUsd: number;
+  conversions: number;
+  leads: number;
+  landingPageClicks: number;
+  engagements: number;
+  videoViews: number;
+  /** Derived KPIs. ctr/cvr/engagementRate are ratios (0-1). */
+  ctr: number;
+  cpc: number;
+  cpm: number;
+  cpl: number;
+  cvr: number;
+  costPerConversion: number;
+  engagementRate: number;
+  dateRange?: DateRange;
+}
+
+interface BaseMetrics {
+  impressions: number;
+  clicks: number;
+  costUsd: number;
+  conversions: number;
+  leads: number;
+  landingPageClicks: number;
+  engagements: number;
+  videoViews: number;
+}
+interface Kpis {
+  ctr: number;
+  cpc: number;
+  cpm: number;
+  cpl: number;
+  cvr: number;
+  costPerConversion: number;
+  engagementRate: number;
+}
+
+const num = (v: unknown) => (typeof v === "number" ? v : Number(v ?? 0)) || 0;
+const r2 = (x: number) => Math.round(x * 100) / 100;
+const r4 = (x: number) => Math.round(x * 10000) / 10000;
+
+function deriveKpis(base: BaseMetrics): Kpis {
+  const { impressions, clicks, costUsd, conversions, leads, engagements } = base;
+  return {
+    ctr: impressions ? r4(clicks / impressions) : 0,
+    cpc: clicks ? r2(costUsd / clicks) : 0,
+    cpm: impressions ? r2((costUsd / impressions) * 1000) : 0,
+    cpl: leads ? r2(costUsd / leads) : 0,
+    cvr: clicks ? r4(conversions / clicks) : 0,
+    costPerConversion: conversions ? r2(costUsd / conversions) : 0,
+    engagementRate: impressions ? r4(engagements / impressions) : 0,
+  };
+}
+
+function rawToBase(raw: RawAnalyticsRow) {
+  return {
+    impressions: num(raw.impressions),
+    clicks: num(raw.clicks),
+    costUsd: r2(num(raw.costInUsd)),
+    conversions: num(raw.externalWebsiteConversions),
+    leads: num(raw.oneClickLeads) + num(raw.qualifiedLeads),
+    landingPageClicks: num(raw.landingPageClicks),
+    engagements: num(raw.totalEngagements),
+    videoViews: num(raw.videoViews),
+  };
+}
+
+/** Normalize a raw analytics row into a MetricRow with derived KPIs. */
+export function normalize(raw: RawAnalyticsRow): MetricRow {
+  const base = rawToBase(raw);
+  const urn = raw.pivotValues?.[0] ?? "";
+  return {
+    entityUrn: urn,
+    entityId: urn.split(":").pop() ?? "",
+    ...base,
+    ...deriveKpis(base),
+    dateRange: raw.dateRange,
+  };
+}
+
+/** Sum a set of rows and recompute KPIs from the totals. */
+export function aggregate(rows: MetricRow[], label = "(total)"): MetricRow {
+  const base = {
+    impressions: 0, clicks: 0, costUsd: 0, conversions: 0, leads: 0,
+    landingPageClicks: 0, engagements: 0, videoViews: 0,
+  };
+  for (const r of rows) {
+    base.impressions += r.impressions; base.clicks += r.clicks; base.costUsd += r.costUsd;
+    base.conversions += r.conversions; base.leads += r.leads; base.landingPageClicks += r.landingPageClicks;
+    base.engagements += r.engagements; base.videoViews += r.videoViews;
+  }
+  base.costUsd = r2(base.costUsd);
+  return { entityUrn: "", entityId: "", name: label, ...base, ...deriveKpis(base) };
+}
+
+/* ----------------------------- ranking & flags ------------------------------ */
+
+export function topBy(rows: MetricRow[], metric: keyof MetricRow, n = 5): MetricRow[] {
+  return [...rows].sort((a, b) => num(b[metric]) - num(a[metric])).slice(0, n);
+}
+export function bottomBy(rows: MetricRow[], metric: keyof MetricRow, n = 5): MetricRow[] {
+  return [...rows].sort((a, b) => num(a[metric]) - num(b[metric])).slice(0, n);
+}
+
+export interface Flag {
+  entityUrn: string;
+  name?: string;
+  kind: "spend_no_conversions" | "high_cpc" | "low_ctr";
+  detail: string;
+}
+
+/** Heuristic flags vs the account average. */
+export function flagRows(rows: MetricRow[], totals: MetricRow): Flag[] {
+  const flags: Flag[] = [];
+  for (const r of rows) {
+    if (r.costUsd >= 50 && r.conversions === 0) {
+      flags.push({ entityUrn: r.entityUrn, name: r.name, kind: "spend_no_conversions", detail: `$${r.costUsd} spent, 0 conversions` });
+    }
+    if (totals.cpc > 0 && r.clicks >= 20 && r.cpc > totals.cpc * 2.5) {
+      flags.push({ entityUrn: r.entityUrn, name: r.name, kind: "high_cpc", detail: `CPC $${r.cpc} vs account avg $${totals.cpc}` });
+    }
+    if (totals.ctr > 0 && r.impressions >= 1000 && r.ctr < totals.ctr * 0.4) {
+      flags.push({ entityUrn: r.entityUrn, name: r.name, kind: "low_ctr", detail: `CTR ${(r.ctr * 100).toFixed(2)}% vs account avg ${(totals.ctr * 100).toFixed(2)}%` });
+    }
+  }
+  return flags;
+}
+
+/* ------------------------------- name lookup -------------------------------- */
+
+export type ReportLevel = "account" | "campaign_group" | "campaign" | "creative";
+const PIVOT: Record<ReportLevel, AnalyticsPivot> = {
+  account: "ACCOUNT",
+  campaign_group: "CAMPAIGN_GROUP",
+  campaign: "CAMPAIGN",
+  creative: "CREATIVE",
+};
+
+/** Best-effort: fill in human names for campaign/group rows (capped concurrency). */
+async function resolveNames(client: LinkedInClient, accountId: string, level: ReportLevel, rows: MetricRow[]) {
+  if (level !== "campaign" && level !== "campaign_group") return;
+  const get = level === "campaign" ? getCampaign : getCampaignGroup;
+  await Promise.all(
+    rows.slice(0, 60).map(async (r) => {
+      try {
+        const e = (await get(client, accountId, r.entityId)) as { name?: string };
+        if (e?.name) r.name = e.name;
+      } catch {
+        /* leave name unset */
+      }
+    }),
+  );
+}
+
+/* ------------------------------ public reports ------------------------------ */
+
+/**
+ * Per-entity performance at a level, under an account (or a parent campaign
+ * group / campaign), over a date range. Rows carry derived KPIs and names.
+ */
+export async function getPerformance(
+  client: LinkedInClient,
+  opts: { accountId: string; level: ReportLevel; dateRange: DateRange; parentId?: string },
+): Promise<MetricRow[]> {
+  const { accountId, level, dateRange, parentId } = opts;
+  let filterType: "accounts" | "campaignGroups" | "campaigns" = "accounts";
+  let ids = [accountId];
+  if (parentId && level === "campaign") { filterType = "campaignGroups"; ids = [parentId]; }
+  if (parentId && level === "creative") { filterType = "campaigns"; ids = [parentId]; }
+
+  const raw = await fetchAnalytics(client, {
+    pivot: PIVOT[level],
+    timeGranularity: "ALL",
+    dateRange,
+    filterType,
+    ids,
+  });
+  const rows = raw.map(normalize).sort((a, b) => b.costUsd - a.costUsd);
+  await resolveNames(client, accountId, level, rows);
+  return rows;
+}
+
+export interface PerformanceSummary {
+  dateRange: DateRange;
+  totals: MetricRow;
+  groups: MetricRow[];
+  topBySpend: MetricRow[];
+  topByCtr: MetricRow[];
+  worstByCpl: MetricRow[];
+  flags: Flag[];
+}
+
+/** Account-level rollup with top/bottom performers and flags. */
+export async function performanceSummary(
+  client: LinkedInClient,
+  opts: { accountId: string; dateRange: DateRange },
+): Promise<PerformanceSummary> {
+  const groups = await getPerformance(client, { accountId: opts.accountId, level: "campaign_group", dateRange: opts.dateRange });
+  const totals = aggregate(groups);
+  const withConversions = groups.filter((g) => g.conversions > 0);
+  return {
+    dateRange: opts.dateRange,
+    totals,
+    groups,
+    topBySpend: topBy(groups, "costUsd", 5),
+    topByCtr: topBy(groups.filter((g) => g.impressions >= 1000), "ctr", 5),
+    worstByCpl: topBy(withConversions, "costPerConversion", 5),
+    flags: flagRows(groups, totals),
+  };
+}
+
+export interface TrendPoint extends MetricRow {
+  periodStart: string;
+  deltas?: Record<string, number>;
+}
+
+const isoWeekStart = (d: LiDate): string => {
+  const dt = utc(d.year, d.month - 1, d.day);
+  const dow = (dt.getUTCDay() + 6) % 7; // Monday = 0
+  dt.setUTCDate(dt.getUTCDate() - dow);
+  return dt.toISOString().slice(0, 10);
+};
+
+const pct = (curr: number, prev: number) => (prev ? r4((curr - prev) / prev) : 0);
+
+/**
+ * Weekly or monthly trend for one entity, with period-over-period deltas on the
+ * headline metrics. Weekly is computed by bucketing daily data (LinkedIn has no
+ * native weekly granularity).
+ */
+export async function performanceTrend(
+  client: LinkedInClient,
+  opts: { level: ReportLevel; entityId: string; dateRange: DateRange; bucket: "weekly" | "monthly" },
+): Promise<TrendPoint[]> {
+  const filterType = ({ account: "accounts", campaign_group: "campaignGroups", campaign: "campaigns", creative: "creatives" } as const)[opts.level];
+  const raw = await fetchAnalytics(client, {
+    pivot: PIVOT[opts.level],
+    timeGranularity: opts.bucket === "monthly" ? "MONTHLY" : "DAILY",
+    dateRange: opts.dateRange,
+    filterType,
+    ids: [opts.entityId],
+  });
+
+  let points: TrendPoint[];
+  if (opts.bucket === "monthly") {
+    points = raw
+      .map(normalize)
+      .map((r) => ({ ...r, periodStart: `${r.dateRange!.start.year}-${String(r.dateRange!.start.month).padStart(2, "0")}` }))
+      .sort((a, b) => a.periodStart.localeCompare(b.periodStart));
+  } else {
+    const buckets = new Map<string, MetricRow[]>();
+    for (const row of raw.map(normalize)) {
+      const key = isoWeekStart(row.dateRange!.start);
+      (buckets.get(key) ?? buckets.set(key, []).get(key)!).push(row);
+    }
+    points = [...buckets.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([periodStart, rows]) => ({ ...aggregate(rows), periodStart }));
+  }
+
+  for (let i = 1; i < points.length; i++) {
+    const c = points[i]!;
+    const p = points[i - 1]!;
+    c.deltas = {
+      impressions: pct(c.impressions, p.impressions),
+      clicks: pct(c.clicks, p.clicks),
+      costUsd: pct(c.costUsd, p.costUsd),
+      conversions: pct(c.conversions, p.conversions),
+      ctr: pct(c.ctr, p.ctr),
+    };
+  }
+  return points;
+}

--- a/packages/core/src/resources/analytics.ts
+++ b/packages/core/src/resources/analytics.ts
@@ -1,0 +1,81 @@
+import type { LinkedInClient } from "../http.js";
+
+/** Reporting levels, mapped to LinkedIn's analytics pivots. */
+export type AnalyticsPivot = "ACCOUNT" | "CAMPAIGN_GROUP" | "CAMPAIGN" | "CREATIVE";
+export type TimeGranularity = "ALL" | "DAILY" | "MONTHLY";
+
+/** What to filter the report to (the parent entity to pull stats under). */
+export type FilterType = "accounts" | "campaignGroups" | "campaigns" | "creatives";
+
+export interface LiDate {
+  year: number;
+  month: number;
+  day: number;
+}
+export interface DateRange {
+  start: LiDate;
+  end: LiDate;
+}
+
+/** Metric fields requested by default (all verified valid against the live API). */
+export const DEFAULT_METRIC_FIELDS = [
+  "impressions",
+  "clicks",
+  "costInUsd",
+  "externalWebsiteConversions",
+  "oneClickLeads",
+  "qualifiedLeads",
+  "landingPageClicks",
+  "companyPageClicks",
+  "totalEngagements",
+  "likes",
+  "comments",
+  "shares",
+  "follows",
+  "videoViews",
+];
+
+const FILTER_URN_TYPE: Record<FilterType, string> = {
+  accounts: "sponsoredAccount",
+  campaignGroups: "sponsoredCampaignGroup",
+  campaigns: "sponsoredCampaign",
+  creatives: "sponsoredCreative",
+};
+
+export interface RawAnalyticsRow {
+  pivotValues: string[];
+  dateRange: DateRange;
+  [metric: string]: unknown;
+}
+
+const encDate = (d: LiDate) => `(year:${d.year},month:${d.month},day:${d.day})`;
+export const encDateRange = (r: DateRange) => `(start:${encDate(r.start)},end:${encDate(r.end)})`;
+
+/**
+ * The analytics engine. Pivots stats by `pivot`, filtered to the given parent
+ * entities (`filterType` + ids), over `dateRange` at `timeGranularity`. Uses the
+ * restli `q=analytics` finder via the client's rawQuery escape hatch (dateRange
+ * and the List() of URNs need literal restli structure with encoded URNs).
+ */
+export async function fetchAnalytics(
+  client: LinkedInClient,
+  opts: {
+    pivot: AnalyticsPivot;
+    timeGranularity: TimeGranularity;
+    dateRange: DateRange;
+    filterType: FilterType;
+    ids: string[];
+    fields?: string[];
+  },
+): Promise<RawAnalyticsRow[]> {
+  const fields = [...(opts.fields ?? DEFAULT_METRIC_FIELDS), "pivotValues", "dateRange"];
+  const urnType = FILTER_URN_TYPE[opts.filterType];
+  const list = opts.ids
+    .map((id) => encodeURIComponent(`urn:li:${urnType}:${id.split(":").pop()}`))
+    .join(",");
+  const rawQuery =
+    `q=analytics&pivot=${opts.pivot}&timeGranularity=${opts.timeGranularity}` +
+    `&dateRange=${encDateRange(opts.dateRange)}&${opts.filterType}=List(${list})&fields=${fields.join(",")}`;
+  const res = await client.request<{ elements: RawAnalyticsRow[] }>({ path: "/adAnalytics", rawQuery });
+  return res.data.elements ?? [];
+}

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -104,6 +104,41 @@ export const AudienceUploadSchema = z.object({
 });
 export type AudienceUploadInput = z.infer<typeof AudienceUploadSchema>;
 
+export const ReportPeriodSchema = z.enum([
+  "last_7_days",
+  "last_30_days",
+  "last_90_days",
+  "month_to_date",
+  "last_month",
+]);
+export const ReportLevelSchema = z.enum(["account", "campaign_group", "campaign", "creative"]);
+
+const dateWindow = {
+  period: ReportPeriodSchema.default("last_30_days"),
+  startDate: z.string().optional().describe("YYYY-MM-DD; with endDate, overrides period"),
+  endDate: z.string().optional().describe("YYYY-MM-DD"),
+};
+
+export const PerformanceQuerySchema = z.object({
+  accountId: z.string().optional(),
+  level: ReportLevelSchema.default("campaign_group").describe("campaign_group=campaign, campaign=ad group, creative=ad"),
+  parentId: z.string().optional().describe("Parent group id (for level=campaign) or campaign id (for level=creative)"),
+  ...dateWindow,
+});
+export type PerformanceQueryInput = z.infer<typeof PerformanceQuerySchema>;
+
+export const SummaryQuerySchema = z.object({ accountId: z.string().optional(), ...dateWindow });
+export type SummaryQueryInput = z.infer<typeof SummaryQuerySchema>;
+
+export const TrendQuerySchema = z.object({
+  level: ReportLevelSchema.default("campaign"),
+  entityId: z.string().describe("Numeric id of the account/group/campaign/creative to trend"),
+  bucket: z.enum(["weekly", "monthly"]).default("weekly"),
+  ...dateWindow,
+  period: ReportPeriodSchema.default("last_90_days"),
+});
+export type TrendQueryInput = z.infer<typeof TrendQuerySchema>;
+
 export const SalesforceAudienceSchema = z.object({
   accountId: z.string(),
   name: z.string().min(1).describe("Audience/segment name"),

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -20,6 +20,13 @@ import {
   createTextAdCreative,
   createSponsoredImageDraft,
   launchFromBrief,
+  getPerformance,
+  performanceSummary,
+  performanceTrend,
+  resolveDateRange,
+  PerformanceQuerySchema,
+  SummaryQuerySchema,
+  TrendQuerySchema,
   CampaignGroupInputSchema,
   CampaignInputSchema,
   TextAdCreativeSchema,
@@ -212,6 +219,57 @@ export function registerTools(server: McpServer): void {
         const liads = await createLiads();
         const input = SponsoredImageCreativeSchema.parse(args);
         return ok(await createSponsoredImageDraft(liads.client, liads.getToken, input));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "performance_summary",
+    "Account performance rollup over a period: totals + KPIs, top campaigns by spend/CTR, worst by cost-per-conversion, and flagged campaigns (spend with no conversions, high CPC, low CTR). Start here for 'how are my ads doing'.",
+    SummaryQuerySchema.shape,
+    async (args) => {
+      try {
+        const liads = await createLiads();
+        const q = SummaryQuerySchema.parse(args);
+        const accountId = q.accountId ?? (await requireDefaultAccountId());
+        return ok(await performanceSummary(liads.client, { accountId, dateRange: resolveDateRange(q) }));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "get_performance",
+    "Per-entity performance with derived KPIs (CTR, CPC, CPM, CPL, conversion rate). level: campaign_group (campaign), campaign (ad group), or creative (ad). Pass parentId to scope campaigns to a group or creatives to a campaign.",
+    PerformanceQuerySchema.shape,
+    async (args) => {
+      try {
+        const liads = await createLiads();
+        const q = PerformanceQuerySchema.parse(args);
+        const accountId = q.accountId ?? (await requireDefaultAccountId());
+        return ok(
+          await getPerformance(liads.client, { accountId, level: q.level, parentId: q.parentId, dateRange: resolveDateRange(q) }),
+        );
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "performance_trend",
+    "Weekly or monthly trend for one entity, with period-over-period deltas on impressions, clicks, spend, conversions, and CTR. Use to spot momentum or creative fatigue.",
+    TrendQuerySchema.shape,
+    async (args) => {
+      try {
+        const liads = await createLiads();
+        const q = TrendQuerySchema.parse(args);
+        return ok(
+          await performanceTrend(liads.client, { level: q.level, entityId: q.entityId, bucket: q.bucket, dateRange: resolveDateRange(q) }),
+        );
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
Builds **idea 3**: analyze performance across every level with derived KPIs, trends, and insights (not just raw numbers).

## What you can do
- **`performance_summary`** / `liam report summary` — account rollup: totals + KPIs, top campaigns by spend and CTR, worst by cost-per-conversion, and **flagged** campaigns (spend with no conversions, high CPC, low CTR vs account average).
- **`get_performance`** / `liam report perf <level>` — per-entity KPI rows at any level: campaign group ("campaign"), campaign ("ad group"), or creative ("ad"). Scope with `parentId`.
- **`performance_trend`** / `liam report trend <level> <id>` — weekly or monthly trend with period-over-period deltas on impressions, clicks, spend, conversions, CTR.

KPIs derived: CTR, CPC, CPM, CPL, conversion rate, cost per conversion, engagement rate. Named periods: `last_7_days`, `last_30_days`, `last_90_days`, `month_to_date`, `last_month` (or explicit start/end).

## Notes
- Uses the live `q=analytics` finder (restli-encoded via the client's rawQuery path). Metric fields verified against the API.
- LinkedIn has no native weekly granularity, so weekly trends bucket daily data into ISO weeks in code.
- Entity names are resolved for readable output.

## Verified live
Against a real account: the summary surfaced an over-spending, under-converting "Retargeting" campaign (CPC $19.39 vs $6.63 avg); the monthly trend showed conversions climbing 0 → 6 → 10. Full build + typecheck; 17 MCP tools.

## Roadmap
Next: cross-reference these LinkedIn conversions with Salesforce opportunities at the account level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)