### PR TITLE
Add web audience-upload section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Register the local MCP server with Claude (Desktop / Code):
    and a strong `MCP_AUTH_TOKEN`).
 4. Your MCP endpoint is `https://<your-app>.vercel.app/api/mcp`.
 
+The hosted app also serves a web **audience upload** section at `/audience`: drop a CSV,
+enter your `MCP_AUTH_TOKEN`, and it creates a matched-audience segment. The upload endpoint
+(`/api/audience`) is gated by the same token.
+
 Connect Claude to the remote server (header carries the secret):
 
 ```bash

--- a/apps/web/app/api/audience/route.ts
+++ b/apps/web/app/api/audience/route.ts
@@ -1,0 +1,59 @@
+import {
+  createLiads,
+  requireDefaultAccountId,
+  extractEmailsFromCsvText,
+  uploadAudienceFromEmails,
+} from "@liads/core";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Audience upload: accepts a CSV (multipart) plus a name, hashes the emails, and
+ * creates a matched-audience DMP segment. Gated by MCP_AUTH_TOKEN, the same shared
+ * secret as the MCP endpoint, so only the operator can write to the ad account.
+ */
+export async function POST(req: Request): Promise<Response> {
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return json({ error: "Expected multipart form data." }, 400);
+  }
+
+  const secret = process.env.MCP_AUTH_TOKEN;
+  if (secret && form.get("token") !== secret) {
+    return json({ error: "Unauthorized. Check your access token." }, 401);
+  }
+
+  const name = String(form.get("name") ?? "").trim();
+  const emailColumn = String(form.get("emailColumn") ?? "email").trim() || "email";
+  const accountOverride = String(form.get("accountId") ?? "").trim();
+  const file = form.get("file");
+
+  if (!name) return json({ error: "Audience name is required." }, 400);
+  if (!(file instanceof File)) return json({ error: "A CSV file is required." }, 400);
+
+  let emails: string[];
+  try {
+    emails = extractEmailsFromCsvText(await file.text(), emailColumn);
+  } catch {
+    return json({ error: `Could not parse the CSV. Check that it has a "${emailColumn}" column.` }, 400);
+  }
+  if (emails.length === 0) {
+    return json({ error: `No emails found in column "${emailColumn}".` }, 400);
+  }
+
+  try {
+    const liads = await createLiads();
+    const accountId = accountOverride || (await requireDefaultAccountId());
+    const result = await uploadAudienceFromEmails(liads.client, liads.getToken, { accountId, name, emails });
+    return json({ ok: true, accountId, ...result });
+  } catch (e) {
+    return json({ error: e instanceof Error ? e.message : "Upload failed." }, 502);
+  }
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}

--- a/apps/web/app/audience/page.tsx
+++ b/apps/web/app/audience/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface UploadResult {
+  ok?: boolean;
+  error?: string;
+  segmentId?: string;
+  uploaded?: number;
+  totalRows?: number;
+  skipped?: number;
+  status?: string;
+  accountId?: string;
+  warnings?: string[];
+}
+
+export default function AudienceUpload() {
+  const [token, setToken] = useState("");
+  const [name, setName] = useState("");
+  const [emailColumn, setEmailColumn] = useState("email");
+  const [accountId, setAccountId] = useState("");
+  const [fileName, setFileName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<UploadResult | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // Remember the token locally so it isn't retyped each visit.
+  useEffect(() => {
+    const t = localStorage.getItem("liam_token");
+    if (t) setToken(t);
+  }, []);
+  useEffect(() => {
+    if (token) localStorage.setItem("liam_token", token);
+  }, [token]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      setResult({ error: "Choose a CSV file first." });
+      return;
+    }
+    setBusy(true);
+    setResult(null);
+    try {
+      const fd = new FormData();
+      fd.set("token", token);
+      fd.set("name", name);
+      fd.set("emailColumn", emailColumn || "email");
+      if (accountId) fd.set("accountId", accountId);
+      fd.set("file", file);
+      const res = await fetch("/api/audience", { method: "POST", body: fd });
+      setResult(await res.json());
+    } catch {
+      setResult({ error: "Network error. Try again." });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="wrap page-narrow">
+      <header className="topbar">
+        <a className="back" href="/">
+          ← LIAM
+        </a>
+        <span className="muted-label">UPLOAD AUDIENCE</span>
+      </header>
+
+      <main className="hero-narrow">
+        <h1 className="section-title">Upload a matched audience</h1>
+        <p className="tagline">
+          Drop a CSV with an email column. Liam <em>SHA256-hashes</em> the emails on the server
+          and creates a matched-audience segment. LinkedIn needs <span className="hot">300+ rows</span>{" "}
+          and takes up to 48h to match.
+        </p>
+
+        <form className="form" onSubmit={onSubmit}>
+          <div className="field">
+            <label htmlFor="token">Access token</label>
+            <input
+              id="token"
+              className="input"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="MCP_AUTH_TOKEN"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="field">
+            <label htmlFor="name">Audience name</label>
+            <input
+              id="name"
+              className="input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Q3 target accounts"
+              required
+            />
+          </div>
+
+          <div className="row-2">
+            <div className="field">
+              <label htmlFor="col">Email column</label>
+              <input id="col" className="input" value={emailColumn} onChange={(e) => setEmailColumn(e.target.value)} />
+            </div>
+            <div className="field">
+              <label htmlFor="acct">Ad account id (optional)</label>
+              <input
+                id="acct"
+                className="input"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                placeholder="defaults to configured account"
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label htmlFor="file">CSV file</label>
+            <label className="filedrop">
+              <input
+                id="file"
+                ref={fileRef}
+                type="file"
+                accept=".csv,text/csv"
+                hidden
+                onChange={(e) => setFileName(e.target.files?.[0]?.name ?? "")}
+              />
+              {fileName ? <span className="filename">{fileName}</span> : <span>Choose a .csv file</span>}
+            </label>
+          </div>
+
+          <button className="submit" type="submit" disabled={busy}>
+            {busy ? "Uploading…" : "Upload audience"}
+          </button>
+        </form>
+
+        {result && (
+          <div className={`result ${result.error ? "err" : ""}`}>
+            {result.error ? (
+              <p>{result.error}</p>
+            ) : (
+              <>
+                <p>
+                  <span className="hot">Segment {result.segmentId}</span> created · status {result.status}
+                </p>
+                <p className="note">
+                  {result.uploaded} hashed emails uploaded
+                  {typeof result.skipped === "number" ? ` · ${result.skipped} skipped` : ""}
+                  {result.accountId ? ` · account ${result.accountId}` : ""}
+                </p>
+                {result.warnings?.map((w, i) => (
+                  <p className="warn" key={i}>
+                    ! {w}
+                  </p>
+                ))}
+              </>
+            )}
+          </div>
+        )}
+      </main>
+
+      <footer className="footer">
+        <span>Created as a private DMP segment. Targetable once matched.</span>
+        <a href="https://github.com/stan-default/liam" target="_blank" rel="noreferrer">
+          github.com/stan-default/liam ↗
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -81,6 +81,21 @@ body::after {
   color: var(--ink);
   font-weight: 600;
 }
+.topright {
+  display: inline-flex;
+  align-items: center;
+  gap: 20px;
+}
+.navlink {
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+.navlink:hover {
+  color: var(--amber);
+  border-color: var(--amber);
+}
 .status {
   display: inline-flex;
   align-items: center;
@@ -188,6 +203,141 @@ body::after {
 .footer a:hover {
   color: var(--amber);
   border-color: var(--amber);
+}
+
+/* ---- audience upload page ---- */
+.page-narrow {
+  max-width: 720px;
+}
+.back {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+.back:hover {
+  color: var(--amber);
+}
+.muted-label {
+  color: var(--faint);
+}
+.hero-narrow {
+  padding: clamp(36px, 8vh, 72px) 0 40px;
+  flex: 1;
+}
+.section-title {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(40px, 8vw, 72px);
+  line-height: 0.9;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin-bottom: 18px;
+}
+.form {
+  display: grid;
+  gap: 20px;
+  margin-top: 36px;
+}
+.row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.field label {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.input {
+  background: #060605;
+  border: 1px solid var(--amber-dim);
+  color: var(--ink);
+  font: inherit;
+  font-size: 14px;
+  padding: 12px 14px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.input:focus {
+  border-color: var(--amber);
+}
+.input::placeholder {
+  color: var(--faint);
+}
+.filedrop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--amber-dim);
+  background: #060605;
+  color: var(--muted);
+  padding: 26px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.filedrop:hover {
+  border-color: var(--amber);
+  color: var(--ink);
+}
+.filename {
+  color: var(--amber);
+}
+.submit {
+  justify-self: start;
+  background: var(--amber);
+  color: #0b0b0c;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 14px 26px;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.05s;
+}
+.submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+.submit:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.submit:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.result {
+  margin-top: 28px;
+  border: 1px solid var(--amber-dim);
+  background: var(--panel);
+  padding: 18px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+.result.err {
+  border-color: #c2412d;
+  color: #f0b8ad;
+}
+.result .note {
+  color: var(--muted);
+  font-size: 13px;
+  margin-top: 6px;
+}
+.result .warn {
+  color: var(--amber);
+  font-size: 13px;
+  margin-top: 6px;
+}
+
+@media (max-width: 560px) {
+  .row-2 { grid-template-columns: 1fr; }
 }
 
 /* staggered entrance */

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,9 +10,14 @@ export default function Home() {
         <span>
           <b>LIAM</b> · LINKEDIN AD MANAGER
         </span>
-        <span className="status">
-          <span className="dot" aria-hidden />
-          ON DUTY
+        <span className="topright">
+          <a className="navlink" href="/audience">
+            Upload audience ↗
+          </a>
+          <span className="status">
+            <span className="dot" aria-hidden />
+            ON DUTY
+          </span>
         </span>
       </header>
 

--- a/packages/core/src/audience.ts
+++ b/packages/core/src/audience.ts
@@ -34,6 +34,12 @@ export function hashAndDedupeEmails(emails: string[]): { hashes: string[]; total
   return { hashes: [...seen], total: emails.length, skipped };
 }
 
+/** Extract raw email values from CSV text (for in-memory uploads, e.g. the web app). */
+export function extractEmailsFromCsvText(text: string, emailColumn: string): string[] {
+  const rows = parse(text, { columns: true, skip_empty_lines: true, trim: true }) as Record<string, string>[];
+  return rows.map((r) => r[emailColumn] ?? "").filter(Boolean);
+}
+
 /** Reads a CSV and returns hashed emails from the given column, deduped. */
 export async function hashEmailsFromCsv(
   csvPath: string,
@@ -109,13 +115,24 @@ async function uploadHashedAudience(
   const uploadUrl = await generateUploadUrl(client, input.accountId);
   const mediaUrn = await uploadListCsv(uploadUrl, csv, token);
   const segment = await createListUploadSegment(client, { accountId: input.accountId, name: input.name });
-  await sleep(5000); // LinkedIn requires ~5s before a segment can accept a list.
-  try {
-    await attachListToSegment(client, segment.id, mediaUrn);
-  } catch (err) {
-    // Don't leave an empty orphan segment behind if the list is rejected.
-    await deleteDmpSegment(client, segment.id).catch(() => {});
-    throw err;
+  // The new segment isn't immediately attachable; LinkedIn suggests ~5s but it
+  // can lag, returning 404. Retry on not-found; fail fast on real rejections.
+  await sleep(5000);
+  let attached = false;
+  for (let attempt = 0; !attached; attempt++) {
+    try {
+      await attachListToSegment(client, segment.id, mediaUrn);
+      attached = true;
+    } catch (err) {
+      const notReady = (err as { status?: number }).status === 404;
+      if (notReady && attempt < 4) {
+        await sleep(3000);
+        continue;
+      }
+      // Don't leave an empty orphan segment behind if the list is rejected.
+      await deleteDmpSegment(client, segment.id).catch(() => {});
+      throw err;
+    }
   }
 
   warnings.push("Segment is matching (up to 48h). Poll get_audience_status; target it once READY.");


### PR DESCRIPTION
Adds a functional **audience upload** section to the hosted app: drop a CSV, it creates a matched-audience DMP segment.

## What's new
- **`/audience` page** — operator-console styled form (access token, audience name, email column, optional account, CSV file). Token is remembered in localStorage. Linked from the home topbar.
- **`/api/audience` route** (Node runtime) — parses the uploaded CSV in memory, hashes emails server-side, and runs the core list-upload flow. Gated by `MCP_AUTH_TOKEN` (same secret as the MCP endpoint), so only the operator can write to the ad account.

## Core
- `extractEmailsFromCsvText` for in-memory CSV parsing (serverless has no file path).
- Attach now **retries on 404** while a freshly created segment becomes available, then fails fast on real rejections. This surfaces the accurate reason (e.g. LinkedIn's 300-row minimum) instead of a confusing "segment not found".

## Verified live
Posted the example CSV: the route parsed it, created the segment, attached, and returned LinkedIn's real validation error for a too-small list; the orphan segment was cleaned up. Builds clean; `/audience` is static, `/api/audience` is a serverless function.

> Note: Vercel Hobby caps request bodies at ~4.5MB, fine for typical lists. Very large CSVs (hundreds of thousands of rows) may need a direct/CLI upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)