### PR TITLE
Auto-clean CSVs on audience upload (contact + company)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,11 @@ modules are thin typed wrappers over `LinkedInClient.request()`.
   `adSegment` urn. Emails are SHA256(lowercased, trimmed). `USER_LIST_UPLOAD` requires
   **300+ rows**; matching takes up to 48h. `uploadAudienceFromCsv` deletes the segment if
   the attach fails (no orphans).
+- **CSV cleaning (`audienceCsv.ts`):** before upload, CSVs are normalized to LinkedIn's matched-
+  audience format. Two types: contact (USER_LIST_UPLOAD, kept column `email`, SHA256-hashed) and
+  company (COMPANY_LIST_UPLOAD, kept `companyname` + `companywebsite`). Header aliases map to
+  canonical names; non-matcher columns are dropped; domains are converted to full `https://`
+  website URLs (LinkedIn matches accounts on the website URL). Type auto-detects from columns.
 - **Audience estimate:** use the `q=targetingCriteriaV2` finder with a restli-encoded
   `targetingCriteria` object (NOT the old dotted `target.includedTargetingFacets...`
   params, which now 400). The HTTP client has a `rawQuery` escape hatch for restli-encoded

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
   `list_facet_entities`, `estimate_audience` (structured spec). Talk in plain language
   ("VPs of demand gen at SaaS companies in the US") and Liam resolves the facets, estimates
   reach, then builds the campaign.
-- **Audiences:** `upload_audience_csv`, `audience_from_salesforce` (SOQL → matched audience),
-  `get_audience_status`
+- **Audiences:** `upload_audience_csv` (auto-cleans the CSV: normalizes column names, drops
+  non-matcher columns, hashes emails, converts company domains to website URLs; supports both
+  contact and company lists), `audience_from_salesforce` (SOQL → matched audience), `get_audience_status`
 - **Conversions:** `list_conversions` (select an existing insight-tag conversion to track).
   `create_campaign` and `launch_from_brief` accept `conversionIds` or `conversionName`, and
   fall back to `defaultConversionName` from config.
@@ -113,7 +114,8 @@ liam auth export                        # print env vars for the hosted (Vercel)
 liam accounts list                      # list accessible ad accounts
 liam targeting search <facet> <query>   # typeahead a facet for entity URNs
 liam targeting estimate <facet> <urns…> # audience size for one facet's URNs
-liam audience upload -n <name> -f <csv> # CSV of emails -> matched-audience segment
+liam audience upload -n <name> -f <csv> # clean + upload a CSV as a matched audience
+liam audience upload -n <name> -f <csv> --dry-run   # preview the cleaned CSV, no upload
 liam audience from-salesforce -n <name> -q "<SOQL>"   # Salesforce query -> matched audience
 liam audience status <segmentId>        # matching status + resolved size
 liam conversions list                   # account conversions (pick one to track)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,8 @@ import {
   exportHostedEnv,
   createLiads,
   listAdAccounts,
-  uploadAudienceFromCsv,
+  uploadAudienceFromFile,
+  cleanAudienceCsv,
   getDmpSegment,
   launchFromBrief,
   requireDefaultAccountId,
@@ -57,21 +58,33 @@ accounts
 const audience = program.command("audience").description("Matched audiences");
 audience
   .command("upload")
-  .description("Upload a CSV of emails as a DMP segment")
-  .option("-a, --account <id>", "Ad account id (defaults to config defaultAccountId)")
+  .description("Clean a CSV (fix columns, drop extras, domains->URLs) and upload as a matched audience")
   .requiredOption("-n, --name <name>", "Audience name")
   .requiredOption("-f, --csv <path>", "CSV file path")
-  .option("-c, --email-column <col>", "Email column header", "email")
+  .option("-a, --account <id>", "Ad account id (defaults to config defaultAccountId)")
+  .option("-t, --type <type>", "contact|company (auto-detected if omitted)")
+  .option("--dry-run", "Show the cleaned result without uploading")
   .action(async (opts) => {
+    const { readFile } = await import("node:fs/promises");
+    if (opts.dryRun) {
+      const clean = cleanAudienceCsv(await readFile(opts.csv, "utf8"), { type: opts.type });
+      console.log(`type: ${clean.type} | rows: ${clean.rowCount} | kept columns: ${clean.columns.join(", ")}`);
+      if (clean.dropped.length) console.log(`dropped: ${clean.dropped.join(", ")}`);
+      clean.warnings.forEach((w: string) => console.warn(`! ${w}`));
+      console.log("\nsample:");
+      console.log(clean.columns.join(","));
+      clean.rows.slice(0, 3).forEach((r) => console.log(clean.columns.map((c) => r[c] ?? "").join(",")));
+      return;
+    }
     const liads = await createLiads();
-    const res = await uploadAudienceFromCsv(liads.client, liads.getToken, {
+    const res = await uploadAudienceFromFile(liads.client, liads.getToken, {
       accountId: opts.account ?? (await requireDefaultAccountId()),
       name: opts.name,
       csvPath: opts.csv,
-      emailColumn: opts.emailColumn,
+      type: opts.type,
     });
-    console.log(`Segment ${res.segmentId} — status ${res.status}`);
-    console.log(`Uploaded ${res.uploaded} hashed emails (${res.skipped} skipped of ${res.totalRows} rows).`);
+    console.log(`Segment ${res.segmentId} (${res.audienceType}) — status ${res.status}`);
+    console.log(`Uploaded ${res.uploaded} (${res.skipped} skipped of ${res.totalRows} rows).`);
     res.warnings.forEach((w: string) => console.warn(`! ${w}`));
   });
 

--- a/packages/core/src/audience.ts
+++ b/packages/core/src/audience.ts
@@ -11,7 +11,9 @@ import {
   deleteDmpSegment,
   MAX_SEGMENT_ROWS,
   RECOMMENDED_MIN_ROWS,
+  type SegmentType,
 } from "./resources/dmpSegments.js";
+import { cleanAudienceCsv, cleanedToCsv, type AudienceType } from "./audienceCsv.js";
 
 /** Normalize (trim + lowercase) and SHA256-hash an email, per LinkedIn's spec. */
 export function hashEmail(email: string): string {
@@ -80,18 +82,63 @@ export async function uploadAudienceFromEmails(
   return uploadHashedAudience(client, getToken, { accountId: input.accountId, name: input.name, hashes, total, skipped });
 }
 
-/** Shared core: validate sizes, build the hashed CSV, run the DMP list-upload flow. */
+/** Upload a CSV (contact or company) to LinkedIn as a matched-audience segment. */
+async function uploadCsvToSegment(
+  client: LinkedInClient,
+  getToken: TokenProvider,
+  input: {
+    accountId: string;
+    name: string;
+    csvText: string;
+    type: SegmentType;
+    uploaded: number;
+    totalRows: number;
+    skipped: number;
+    warnings: string[];
+  },
+): Promise<AudienceUploadResult> {
+  const token = await getToken();
+  const uploadUrl = await generateUploadUrl(client, input.accountId);
+  const mediaUrn = await uploadListCsv(uploadUrl, input.csvText, token);
+  const segment = await createListUploadSegment(client, { accountId: input.accountId, name: input.name, type: input.type });
+
+  // The new segment isn't immediately attachable; LinkedIn suggests ~5s but it
+  // can lag with a 404. Retry on not-found; fail fast on real rejections.
+  await sleep(5000);
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await attachListToSegment(client, segment.id, mediaUrn);
+      break;
+    } catch (err) {
+      if ((err as { status?: number }).status === 404 && attempt < 4) {
+        await sleep(3000);
+        continue;
+      }
+      await deleteDmpSegment(client, segment.id).catch(() => {});
+      throw err;
+    }
+  }
+
+  return {
+    segmentId: segment.id,
+    uploaded: input.uploaded,
+    totalRows: input.totalRows,
+    skipped: input.skipped,
+    status: "PROCESSING",
+    warnings: [...input.warnings, "Segment is matching (up to 48h). Poll get_audience_status; target it once READY."],
+  };
+}
+
+/** Shared core for email/contact uploads: validate sizes, hash, upload. */
 async function uploadHashedAudience(
   client: LinkedInClient,
   getToken: TokenProvider,
-  input: { accountId: string; name: string; hashes: string[]; total: number; skipped: number },
+  input: { accountId: string; name: string; hashes: string[]; total: number; skipped: number; preWarnings?: string[] },
 ): Promise<AudienceUploadResult> {
   const { hashes, total, skipped } = input;
-  const warnings: string[] = [];
+  const warnings = [...(input.preWarnings ?? [])];
 
-  if (hashes.length === 0) {
-    throw new Error("No valid emails to upload.");
-  }
+  if (hashes.length === 0) throw new Error("No valid emails to upload.");
   if (hashes.length > MAX_SEGMENT_ROWS) {
     throw new Error(`List has ${hashes.length} emails; LinkedIn caps a single upload at ${MAX_SEGMENT_ROWS}.`);
   }
@@ -102,23 +149,62 @@ async function uploadHashedAudience(
   }
   if (skipped > 0) warnings.push(`Skipped ${skipped} rows with missing/invalid emails.`);
 
-  // Build the hashed-email CSV LinkedIn expects (single `email` column of hashes).
-  const csv = `email\n${hashes.join("\n")}\n`;
+  return uploadCsvToSegment(client, getToken, {
+    accountId: input.accountId,
+    name: input.name,
+    csvText: `email\n${hashes.join("\n")}\n`,
+    type: "USER_LIST_UPLOAD",
+    uploaded: hashes.length,
+    totalRows: total,
+    skipped,
+    warnings,
+  });
+}
 
-  const token = await getToken();
-  const uploadUrl = await generateUploadUrl(client, input.accountId);
-  const mediaUrn = await uploadListCsv(uploadUrl, csv, token);
-  const segment = await createListUploadSegment(client, { accountId: input.accountId, name: input.name });
-  await sleep(5000); // LinkedIn requires ~5s before a segment can accept a list.
-  try {
-    await attachListToSegment(client, segment.id, mediaUrn);
-  } catch (err) {
-    // Don't leave an empty orphan segment behind if the list is rejected.
-    await deleteDmpSegment(client, segment.id).catch(() => {});
-    throw err;
+/** Min recommended rows for a company list (contacts use RECOMMENDED_MIN_ROWS). */
+const RECOMMENDED_MIN_COMPANIES = 1000;
+
+/**
+ * Clean a CSV (fix column names, drop non-matcher columns, turn domains into
+ * website URLs) and upload it as the right list type (auto-detected, or forced
+ * via `type`). Contacts are hashed; companies upload name + website.
+ */
+export async function uploadAudienceFromFile(
+  client: LinkedInClient,
+  getToken: TokenProvider,
+  input: { accountId: string; name: string; csvPath: string; type?: AudienceType },
+): Promise<AudienceUploadResult & { audienceType: AudienceType }> {
+  const text = await readFile(input.csvPath, "utf8");
+  const clean = cleanAudienceCsv(text, { type: input.type });
+  if (clean.rowCount === 0) throw new Error("No usable rows after cleaning the CSV.");
+
+  if (clean.type === "contact") {
+    const { hashes, total, skipped } = hashAndDedupeEmails(clean.rows.map((r) => r.email ?? ""));
+    const res = await uploadHashedAudience(client, getToken, {
+      accountId: input.accountId,
+      name: input.name,
+      hashes,
+      total,
+      skipped,
+      preWarnings: clean.warnings,
+    });
+    return { ...res, audienceType: "contact" };
   }
 
-  warnings.push("Segment is matching (up to 48h). Poll get_audience_status; target it once READY.");
-
-  return { segmentId: segment.id, uploaded: hashes.length, totalRows: total, skipped, status: "PROCESSING", warnings };
+  // company
+  const warnings = [...clean.warnings];
+  if (clean.rowCount < RECOMMENDED_MIN_COMPANIES) {
+    warnings.push(`Only ${clean.rowCount} companies. LinkedIn recommends >= ${RECOMMENDED_MIN_COMPANIES}.`);
+  }
+  const res = await uploadCsvToSegment(client, getToken, {
+    accountId: input.accountId,
+    name: input.name,
+    csvText: cleanedToCsv(clean),
+    type: "COMPANY_LIST_UPLOAD",
+    uploaded: clean.rowCount,
+    totalRows: clean.rowCount,
+    skipped: 0,
+    warnings,
+  });
+  return { ...res, audienceType: "company" };
 }

--- a/packages/core/src/audienceCsv.ts
+++ b/packages/core/src/audienceCsv.ts
@@ -1,0 +1,114 @@
+import { parse } from "csv-parse/sync";
+
+/**
+ * Cleans a messy CSV into LinkedIn's required matched-audience format before
+ * upload: normalizes column names (aliases -> canonical), drops everything that
+ * isn't a matcher, and turns company domains into website URLs.
+ *
+ * Two list types:
+ *  - contact (USER_LIST_UPLOAD): matched by email. Kept column: `email`.
+ *  - company (COMPANY_LIST_UPLOAD): matched by website. Kept columns:
+ *    `companyname`, `companywebsite` (full https:// URL, since LinkedIn matches
+ *    accounts on the website URL).
+ */
+
+export type AudienceType = "contact" | "company";
+
+const normKey = (h: string) => h.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const EMAIL_KEYS = new Set(
+  ["email", "emailaddress", "emailaddr", "mail", "workemail", "useremail", "primaryemail", "emailaddress1"],
+);
+const COMPANY_NAME_KEYS = new Set(
+  ["companyname", "company", "accountname", "account", "organization", "organisation", "companylegalname", "name"],
+);
+const WEBSITE_KEYS = new Set(
+  ["companywebsite", "website", "websiteurl", "url", "web", "companyurl", "companywebsiteurl", "homepage",
+   "domain", "companydomain", "companyemaildomain", "emaildomain", "websitedomain", "webdomain"],
+);
+
+/** Turn a domain or messy URL into a clean https:// website URL (or "" if not a domain). */
+export function toWebsiteUrl(raw: string): string {
+  let s = (raw ?? "").trim().toLowerCase();
+  if (!s) return "";
+  s = s.replace(/^https?:\/\//, "").replace(/^www\./, "");
+  s = s.split(/[/?#]/)[0]!.replace(/:\d+$/, "");
+  if (!s.includes(".")) return "";
+  return `https://${s}`;
+}
+
+export interface CleanedCsv {
+  type: AudienceType;
+  /** Canonical columns kept in the output. */
+  columns: string[];
+  /** Cleaned rows (raw email for contacts; website is already a URL for companies). */
+  rows: Record<string, string>[];
+  /** Original headers that were dropped. */
+  dropped: string[];
+  rowCount: number;
+  warnings: string[];
+}
+
+function findHeader(headers: string[], keys: Set<string>): string | undefined {
+  return headers.find((h) => keys.has(normKey(h)));
+}
+
+function detectType(headers: string[]): AudienceType {
+  if (findHeader(headers, EMAIL_KEYS)) return "contact";
+  if (findHeader(headers, COMPANY_NAME_KEYS) || findHeader(headers, WEBSITE_KEYS)) return "company";
+  throw new Error("Could not detect list type from columns. Pass an explicit type (contact|company).");
+}
+
+/** Parse + normalize a CSV into LinkedIn's matched-audience format. */
+export function cleanAudienceCsv(text: string, opts: { type?: AudienceType } = {}): CleanedCsv {
+  const parsed = parse(text, { columns: true, skip_empty_lines: true, trim: true }) as Record<string, string>[];
+  const headers = parsed.length ? Object.keys(parsed[0]!) : [];
+  if (headers.length === 0) throw new Error("CSV has no header row.");
+
+  const type = opts.type ?? detectType(headers);
+  const warnings: string[] = [];
+
+  if (type === "contact") {
+    const emailCol = findHeader(headers, EMAIL_KEYS);
+    if (!emailCol) throw new Error("No email column found for a contact list.");
+    const rows = parsed.map((r) => ({ email: (r[emailCol] ?? "").trim().toLowerCase() })).filter((r) => r.email);
+    const dropped = headers.filter((h) => h !== emailCol);
+    if (dropped.length) warnings.push(`Dropped ${dropped.length} non-matcher column(s): ${dropped.join(", ")}.`);
+    return { type, columns: ["email"], rows, dropped, rowCount: rows.length, warnings };
+  }
+
+  // company
+  const nameCol = findHeader(headers, COMPANY_NAME_KEYS);
+  const webCol = findHeader(headers, WEBSITE_KEYS);
+  if (!webCol && !nameCol) throw new Error("No company name or website/domain column found.");
+  if (!webCol) warnings.push("No website/domain column found; matching on company name only.");
+
+  const columns = [...(nameCol ? ["companyname"] : []), ...(webCol ? ["companywebsite"] : [])];
+  let convertedDomains = 0;
+  const rows: Record<string, string>[] = [];
+  for (const r of parsed) {
+    const out: Record<string, string> = {};
+    if (nameCol) out.companyname = (r[nameCol] ?? "").trim();
+    if (webCol) {
+      const url = toWebsiteUrl(r[webCol] ?? "");
+      if (url) {
+        out.companywebsite = url;
+        if (!/^https?:\/\//i.test((r[webCol] ?? "").trim())) convertedDomains += 1;
+      }
+    }
+    if (out.companyname || out.companywebsite) rows.push(out);
+  }
+  const dropped = headers.filter((h) => h !== nameCol && h !== webCol);
+  if (dropped.length) warnings.push(`Dropped ${dropped.length} non-matcher column(s): ${dropped.join(", ")}.`);
+  if (convertedDomains) warnings.push(`Converted ${convertedDomains} domain(s) to https:// website URLs.`);
+
+  return { type, columns, rows, dropped, rowCount: rows.length, warnings };
+}
+
+/** Render a CleanedCsv back to CSV text (used for company uploads and dry-run preview). */
+export function cleanedToCsv(clean: CleanedCsv): string {
+  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const head = clean.columns.join(",");
+  const body = clean.rows.map((r) => clean.columns.map((c) => esc(r[c] ?? "")).join(",")).join("\n");
+  return `${head}\n${body}\n`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from "./resources/conversions.js";
 
 // High-level workflows
 export * from "./audience.js";
+export * from "./audienceCsv.js";
 export * from "./creative.js";
 export * from "./orchestrate.js";
 export * from "./resources/analytics.js";

--- a/packages/core/src/orchestrate.ts
+++ b/packages/core/src/orchestrate.ts
@@ -1,6 +1,6 @@
 import type { Liads } from "./client.js";
 import type { LaunchFromBriefInput } from "./schemas.js";
-import { uploadAudienceFromCsv } from "./audience.js";
+import { uploadAudienceFromFile } from "./audience.js";
 import { createCampaignGroup } from "./resources/campaignGroups.js";
 import { createCampaign } from "./resources/campaigns.js";
 import { createTextAdCreative } from "./resources/creatives.js";
@@ -36,7 +36,11 @@ export async function launchFromBrief(
   // to the campaign in this same run — we surface the segment id to attach later.
   const audienceSegmentUrn: string | undefined = undefined;
   if (input.audience) {
-    const result = await uploadAudienceFromCsv(client, getToken, { ...input.audience, accountId: input.accountId });
+    const result = await uploadAudienceFromFile(client, getToken, {
+      accountId: input.accountId,
+      name: input.audience.name,
+      csvPath: input.audience.csvPath,
+    });
     warnings.push(...result.warnings);
     warnings.push(
       `Audience "${input.audience.name}" uploaded as segment ${result.segmentId} (${result.uploaded} hashed emails). Attach its adSegment urn to this campaign once it is READY.`,

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -9,7 +9,7 @@ import {
   listFacetEntities,
   COMMON_FACETS,
   TargetingSpecSchema,
-  uploadAudienceFromCsv,
+  uploadAudienceFromFile,
   audienceFromSalesforce,
   listConversions,
   getDmpSegment,
@@ -31,7 +31,6 @@ import {
   CampaignInputSchema,
   TextAdCreativeSchema,
   SponsoredImageCreativeSchema,
-  AudienceUploadSchema,
   LaunchFromBriefSchema,
 } from "@liads/core";
 
@@ -113,12 +112,18 @@ export function registerTools(server: McpServer): void {
 
   server.tool(
     "upload_audience_csv",
-    "Upload a CSV of emails as a matched-audience DMP segment (SHA256-hashed). Requires the Audiences product. Matching takes up to 48h.",
-    AudienceUploadSchema.shape,
-    async (args) => {
+    "Clean a CSV at csvPath and upload it as a matched-audience DMP segment. Auto-detects contact (email) vs company (account) lists, normalizes column names, drops non-matcher columns, hashes emails, and converts company domains to website URLs. Requires the Audiences product; matching takes up to 48h.",
+    {
+      accountId: z.string().optional(),
+      name: z.string(),
+      csvPath: z.string().describe("Path to the CSV file on the server"),
+      type: z.enum(["contact", "company"]).optional().describe("Force the list type; auto-detected if omitted"),
+    },
+    async ({ accountId, name, csvPath, type }) => {
       try {
         const liads = await createLiads();
-        return ok(await uploadAudienceFromCsv(liads.client, liads.getToken, AudienceUploadSchema.parse(args)));
+        const acct = accountId ?? (await requireDefaultAccountId());
+        return ok(await uploadAudienceFromFile(liads.client, liads.getToken, { accountId: acct, name, csvPath, type }));
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
Makes the CLI/MCP audience upload **fix messy CSVs automatically** before sending them to LinkedIn, and adds company (account) list support.

## What it does
For any uploaded CSV, Liam now:
- **Fixes column names** — maps aliases (e.g. "E-mail Address", "Account Name", "Domain") to LinkedIn's canonical headers.
- **Drops every column that isn't a matcher.**
- **Auto-detects the list type** — contact (matched by email) vs company (matched by website).
- **Converts domains to website URLs** — `globex.io` and `https://www.acme.com/home` both become `https://globex.io` / `https://acme.com`, since LinkedIn matches accounts on the website URL.
- Hashes emails for contact lists; uploads `companyname` + `companywebsite` for company lists.

## Interfaces
- `liam audience upload -n <name> -f <csv> [--type contact|company] [--dry-run]`. `--dry-run` previews the cleaned result (detected type, kept/dropped columns, sample rows) without uploading.
- MCP `upload_audience_csv` gains the same cleaning + a `type` override; `launch_from_brief`'s audience step cleans too.

## Notes
- Adds `COMPANY_LIST_UPLOAD` support (we previously only did contacts).
- Re-includes the attach-on-404 retry so new segments attach reliably (this and PR #4 both touch `audience.ts`; whichever merges second may need a one-line conflict resolve).

## Verified live
Messy contact and company CSVs cleaned correctly (emails lowercased/trimmed, "Account Name"→companyname, "Domain"→`https://` URL, extras dropped), and the upload reached LinkedIn end to end. Full build + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)