### PR TITLE
Add ENGAGEMENT objective; force Audience Expansion + Audience Network off

### DIFF
--- a/packages/core/src/orchestrate.ts
+++ b/packages/core/src/orchestrate.ts
@@ -95,7 +95,6 @@ export async function launchFromBrief(
     runSchedule: input.runSchedule,
     status: "DRAFT",
     targeting: spec,
-    offsiteDeliveryEnabled: false,
     politicalIntent: "NOT_POLITICAL",
     conversionIds,
   });

--- a/packages/core/src/resources/campaigns.ts
+++ b/packages/core/src/resources/campaigns.ts
@@ -31,9 +31,14 @@ export async function createCampaign(
     runSchedule: input.runSchedule,
     status: input.status,
     targetingCriteria,
-    offsiteDeliveryEnabled: input.offsiteDeliveryEnabled ?? false,
+    // Hard rule: never enable Audience Expansion or the LinkedIn Audience
+    // Network. Both are forced off on every ad set we create — they spend
+    // budget on low-quality, off-target reach. Not configurable on purpose.
+    audienceExpansionEnabled: false,
+    offsiteDeliveryEnabled: false,
     politicalIntent: input.politicalIntent ?? "NOT_POLITICAL",
   };
+  if (input.objectiveType) body.objectiveType = input.objectiveType;
   if (input.dailyBudget) body.dailyBudget = input.dailyBudget;
   if (input.totalBudget) body.totalBudget = input.totalBudget;
   if (input.unitCost) body.unitCost = input.unitCost;

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -30,6 +30,21 @@ export const CampaignTypeSchema = z.enum([
 ]);
 
 /**
+ * LinkedIn campaign objective. Use ENGAGEMENT to sponsor another member's post
+ * (thought-leader ads, e.g. boosting a CEO's post) — LinkedIn requires the
+ * objective be ENGAGEMENT for that ad format.
+ */
+export const ObjectiveTypeSchema = z.enum([
+  "BRAND_AWARENESS",
+  "ENGAGEMENT",
+  "JOB_APPLICANT",
+  "LEAD_GENERATION",
+  "VIDEO_VIEW",
+  "WEBSITE_CONVERSION",
+  "WEBSITE_VISIT",
+]);
+
+/**
  * Structured targeting. Keys are short facet names (locations, seniorities,
  * titles, industries, staffCountRanges, skills, audienceMatchingSegments, ...);
  * values are entity URNs resolved via the search_targeting tool. URNs within a
@@ -46,6 +61,9 @@ export const CampaignInputSchema = z.object({
   campaignGroupId: z.string().describe("Numeric campaign group id"),
   name: z.string().min(1),
   type: CampaignTypeSchema.default("SPONSORED_UPDATES"),
+  objectiveType: ObjectiveTypeSchema.optional().describe(
+    "Campaign objective. Required to be ENGAGEMENT to sponsor another member's post (thought-leader ads).",
+  ),
   costType: z.enum(["CPC", "CPM", "CPV"]).default("CPM"),
   dailyBudget: MoneySchema.optional(),
   totalBudget: MoneySchema.optional(),
@@ -62,8 +80,6 @@ export const CampaignInputSchema = z.object({
   targeting: TargetingSpecSchema.optional(),
   audienceSegmentUrn: z.string().optional().describe("urn:li:adSegment:... to target a matched audience"),
   geoUrns: z.array(z.string()).optional().describe("urn:li:geo:... locations to include"),
-  /** LinkedIn Audience Network (off-LinkedIn) delivery. Required by the API; defaults off. */
-  offsiteDeliveryEnabled: z.boolean().default(false),
   /** Political-ad self-declaration, mandatory for EU targeting. Defaults to not political. */
   politicalIntent: z.enum(["NOT_POLITICAL", "POLITICAL", "NOT_DECLARED"]).default("NOT_POLITICAL"),
   /** Existing conversion ids to associate (select an insight-tag conversion to track). */


### PR DESCRIPTION
## Why

Two problems surfaced while creating a real engagement ad set:

1. **No way to set the campaign objective.** To sponsor *someone else's* post (thought-leader ads, e.g. boosting a CEO's post), LinkedIn requires the campaign objective to be **ENGAGEMENT**. Liam's `create_campaign` didn't expose `objectiveType` at all, so the draft came out with no objective and had to be fixed by hand in Campaign Manager.

2. **Unsafe defaults.** New ad sets were coming out with **Audience Expansion** and the **LinkedIn Audience Network** enabled. Both spend budget on low-quality, off-target reach and must always be off. These had to be toggled off manually in the UI every time.

## What changed

- Add an optional `objectiveType` to `CampaignInputSchema` (`BRAND_AWARENESS`, `ENGAGEMENT`, `JOB_APPLICANT`, `LEAD_GENERATION`, `VIDEO_VIEW`, `WEBSITE_CONVERSION`, `WEBSITE_VISIT`) and pass it through to the API. The MCP `create_campaign` tool picks this up automatically (it derives from the schema shape).
- Hard-force `audienceExpansionEnabled: false` and `offsiteDeliveryEnabled: false` on every campaign body in `createCampaign`. **Not configurable on purpose** — there's no input to turn either on.
- Removed the `offsiteDeliveryEnabled` input from the schema and from `orchestrate.ts`, since it's now always off.

## Notes

- `pnpm -r build` passes across all packages.
- No behavior change for callers that omit `objectiveType` (it's optional and only added to the body when present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)