### PR TITLE
Auto-apply default audience exclusions and default conversion

### DIFF
--- a/packages/core/src/orchestrate.ts
+++ b/packages/core/src/orchestrate.ts
@@ -96,6 +96,9 @@ export async function launchFromBrief(
     status: "DRAFT",
     targeting: spec,
     politicalIntent: "NOT_POLITICAL",
+    applyDefaultExclusions: true,
+    // Conversion is resolved above (explicit id, brief name, or config default).
+    applyDefaultConversion: false,
     conversionIds,
   });
   if (conversionIds.length) warnings.push(`Tracking ${conversionIds.length} conversion(s) on the campaign.`);

--- a/packages/core/src/resources/campaigns.ts
+++ b/packages/core/src/resources/campaigns.ts
@@ -1,8 +1,9 @@
 import type { LinkedInClient } from "../http.js";
 import type { CampaignInput } from "../schemas.js";
 import { sponsoredAccountUrn, campaignGroupUrn } from "../urns.js";
-import { buildTargetingCriteria, geoSegmentSpec } from "./targeting.js";
-import { associateCampaignWithConversion } from "./conversions.js";
+import { buildTargetingCriteria, geoSegmentSpec, withDefaultExclusions } from "./targeting.js";
+import { associateCampaignWithConversion, resolveConversionIdByName } from "./conversions.js";
+import { loadConfig } from "../config.js";
 import type { CreatedEntity } from "./campaignGroups.js";
 
 /**
@@ -15,11 +16,14 @@ export async function createCampaign(
   input: CampaignInput,
 ): Promise<CreatedEntity> {
   // Targeting precedence: explicit raw criteria > structured spec > geo/segment shorthand.
-  const targetingCriteria =
+  const baseCriteria =
     input.targetingCriteria ??
     buildTargetingCriteria(
       input.targeting ?? geoSegmentSpec(input.geoUrns, input.audienceSegmentUrn),
     );
+  // Standing rule: apply default audience exclusions unless explicitly opted out.
+  const targetingCriteria =
+    (input.applyDefaultExclusions ?? true) ? withDefaultExclusions(baseCriteria) : baseCriteria;
 
   const body: Record<string, unknown> = {
     account: sponsoredAccountUrn(input.accountId),
@@ -50,8 +54,18 @@ export async function createCampaign(
   });
   if (!res.restliId) throw new Error("Campaign created but no id returned");
 
+  // Conversions: use explicit ids if given, otherwise fall back to the account's
+  // default conversion (config.defaultConversionName) unless opted out.
+  let conversionIds = input.conversionIds ?? [];
+  if (conversionIds.length === 0 && (input.applyDefaultConversion ?? true)) {
+    const name = (await loadConfig()).defaultConversionName;
+    if (name) {
+      const id = await resolveConversionIdByName(client, input.accountId, name);
+      if (id) conversionIds = [id];
+    }
+  }
   // Select existing conversions (e.g. an insight tag) for this campaign.
-  for (const conversionId of input.conversionIds ?? []) {
+  for (const conversionId of conversionIds) {
     await associateCampaignWithConversion(client, input.accountId, conversionId, res.restliId);
   }
   return { id: res.restliId };

--- a/packages/core/src/resources/targeting.ts
+++ b/packages/core/src/resources/targeting.ts
@@ -42,6 +42,35 @@ export interface TargetingSpec {
 const nonEmpty = (rec?: Record<string, string[]>) =>
   Object.entries(rec ?? {}).filter(([, urns]) => urns && urns.length > 0);
 
+/**
+ * Standing default audience exclusions applied to every campaign unless turned
+ * off. Excludes live customers, competitors, and the manual exclude list so
+ * spend stays on net-new in-market accounts.
+ */
+export const DEFAULT_EXCLUSION_SEGMENT_URNS = [
+  "urn:li:adSegment:32099796", // Live Customer
+  "urn:li:adSegment:24661476", // Exclude Competitors
+  "urn:li:adSegment:31797196", // Exclude List
+];
+
+/**
+ * Merge default audience-exclusion segments into a built targetingCriteria,
+ * unioning (deduped) with any existing audienceMatchingSegments exclusions.
+ * Returns a shallow-updated copy; preserves any other exclude clauses.
+ */
+export function withDefaultExclusions(
+  criteria: Record<string, unknown>,
+  segmentUrns: string[] = DEFAULT_EXCLUSION_SEGMENT_URNS,
+): Record<string, unknown> {
+  if (segmentUrns.length === 0) return criteria;
+  const facet = facetUrn("audienceMatchingSegments");
+  const exclude = (criteria.exclude as { or?: Record<string, string[]> } | undefined) ?? {};
+  const or = { ...(exclude.or ?? {}) };
+  const existing = Array.isArray(or[facet]) ? or[facet] : [];
+  or[facet] = Array.from(new Set([...existing, ...segmentUrns]));
+  return { ...criteria, exclude: { ...exclude, or } };
+}
+
 /** Builds the targetingCriteria object for campaign create/update from a spec. */
 export function buildTargetingCriteria(spec: TargetingSpec): Record<string, unknown> {
   const and = nonEmpty(spec.include).map(([name, urns]) => ({ or: { [facetUrn(name)]: urns } }));

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -84,6 +84,10 @@ export const CampaignInputSchema = z.object({
   politicalIntent: z.enum(["NOT_POLITICAL", "POLITICAL", "NOT_DECLARED"]).default("NOT_POLITICAL"),
   /** Existing conversion ids to associate (select an insight-tag conversion to track). */
   conversionIds: z.array(z.string()).optional(),
+  /** Apply the standing default audience exclusions (live customers, competitors, exclude list). Set false to skip. */
+  applyDefaultExclusions: z.boolean().default(true),
+  /** When no conversionIds are given, attach the account's default conversion. Set false to skip. */
+  applyDefaultConversion: z.boolean().default(true),
 });
 export type CampaignInput = z.infer<typeof CampaignInputSchema>;
 


### PR DESCRIPTION
## Why

Stan applies the same exclusions and conversion to every campaign by hand. This enforces them in code so `create_campaign` (and the MCP tool) get them automatically.

> **Stacked on #8** — base is `feat/engagement-objective-force-safe-toggles`. Merge #8 first, then rebase/retarget this onto `main`.

## What changed

- **Default audience exclusions** merged into `targetingCriteria` on every campaign:
  - Live Customer (`urn:li:adSegment:32099796`)
  - Exclude Competitors (`urn:li:adSegment:24661476`)
  - Exclude List (`urn:li:adSegment:31797196`)

  Unioned and deduped with any existing `audienceMatchingSegments` exclusions, so explicit exclusions are preserved, not clobbered.
- **Default conversion:** when no `conversionIds` are passed, `createCampaign` resolves `config.defaultConversionName` ("Default Meeting Booked - Insight Tag") and attaches only that one.
- **Opt-out flags** on the schema: `applyDefaultExclusions` and `applyDefaultConversion`, both default `true`. The MCP tool picks these up automatically from the schema shape.
- `orchestrate.ts` keeps owning conversion resolution (it also handles the brief's `conversionName`), so `launchFromBrief` sets `applyDefaultConversion: false` but still gets the default exclusions.

## Verification

- `pnpm -r build` passes across all packages.
- Spot-checked the merge helper: overlapping segments dedupe, an empty exclude block gets the three defaults, and the include tree is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)