### PR TITLE
Competitor ad intelligence: read any company's ads from the LinkedIn Ad Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
 - **Reporting:** `performance_summary` (account rollup + top/bottom + flags), `get_performance`
   (per-entity KPIs at any level), `performance_trend` (weekly/monthly with deltas). KPIs: CTR,
   CPC, CPM, CPL, conversion rate, cost per conversion. Levels: campaign_group → campaign → creative.
+- **Competitor intel:** `inspect_competitor_ads` — read any company's ads from the LinkedIn Ad
+  Library (no ad-account access needed). The **official Ad Library API** (`GET /rest/adLibrary`,
+  requires the "LinkedIn Ad Library" product grant) returns structured metadata — advertiser, payer,
+  format, and for EU-served ads run dates, impression ranges, per-country split, and targeting facets —
+  but no creative. A **Playwright scraper** of the public library supplies the ad copy/image. Engines
+  (`engine`): `api` (metadata only, fast, works hosted), `scraper` (copy via browser, local, supports
+  company-id), and `auto` (default — API metadata + copy layered from each ad's detail page, falling
+  back to the scraper if the API isn't provisioned). Search by `advertiser` name or `keyword` (the API
+  has no company-id or date filter). CLI: `liam competitor ads`.
 
 ### Targeting spec
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,13 @@ creates drafts, and nothing spends until you activate it.
 - **Reporting and insights** — per-level performance (account, campaign group, campaign,
   creative), weekly/monthly trends with deltas, derived KPIs (CTR, CPC, CPM, CPL, conversion
   rate, cost per conversion), and heuristic flags.
+- **Competitor ad intelligence** — read any company's live and recent ads from the LinkedIn Ad
+  Library (no ad-account access needed). The official Ad Library API (`GET /rest/adLibrary`, verified
+  live) returns structured metadata — advertiser, payer, format, and for EU-served ads run dates,
+  impression ranges, per-country split, and targeting facets — but no creative; a Playwright scraper of
+  the public library layers in the ad copy/image. Engines `api` / `scraper` / `auto` (default: API
+  metadata + copy from each ad's detail page, scraper fallback if unprovisioned). Synthesize messaging
+  themes and how the account is run from the result. CLI `competitor ads`, MCP `inspect_competitor_ads`.
 - **Delivery** — local CLI, local MCP server, and a single-tenant hosted MCP on Vercel.
 
 ## Planned

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Workspace packages ship prebuilt dist; no transpile needed.
-  serverExternalPackages: ["@liads/core", "@liads/mcp"],
+  // playwright is only used by the local competitor-ad scanner (lazy-imported in
+  // @liads/core); keep it external so the hosted bundle never tries to resolve it.
+  serverExternalPackages: ["@liads/core", "@liads/mcp", "playwright", "playwright-core"],
 };
 
 export default nextConfig;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,8 @@ import {
   getPerformance,
   performanceTrend,
   resolveDateRange,
+  scanCompetitorAds,
+  parseAdvertiserQuery,
 } from "@liads/core";
 
 const program = new Command();
@@ -192,6 +194,60 @@ report
       const d = dc !== undefined ? ` (spend ${dc >= 0 ? "+" : ""}${pctf(dc)})` : "";
       console.log(`${p.periodStart}\t$${p.costUsd}\timpr ${p.impressions}\tCTR ${pctf(p.ctr)}\tconv ${p.conversions}${d}`);
     }
+  });
+
+const competitor = program.command("competitor").description("Competitor ad intelligence (public LinkedIn Ad Library)");
+competitor
+  .command("ads <advertiser>")
+  .description("Scan a competitor's ads from the public Ad Library. <advertiser> = company name, numeric company id, or an ad-library/company URL.")
+  .option("--company-id <id>", "Force a numeric LinkedIn company id (most precise)")
+  .option("-k, --keyword <text>", "Keyword search across ad copy instead of an advertiser")
+  .option("-c, --country <codes>", "Comma-separated ISO country codes, e.g. US,GB")
+  .option("-e, --engine <engine>", "auto | api | scraper", "auto")
+  .option("-m, --max <n>", "Max ads to collect", (v) => parseInt(v, 10), 50)
+  .option("--no-deep", "auto: skip copy layering (API metadata only); scraper: skip per-ad detail — faster")
+  .option("--headed", "Scraper: show the browser window (debug)")
+  .option("--json", "Print raw JSON instead of a summary")
+  .action(async (advertiser: string, opts) => {
+    const parsed = parseAdvertiserQuery(advertiser);
+    const scan = await scanCompetitorAds({
+      advertiser: opts.companyId ? undefined : parsed.advertiser,
+      companyId: opts.companyId ?? parsed.companyId,
+      keyword: opts.keyword ?? parsed.keyword,
+      countries: opts.country ? String(opts.country).split(",").map((s: string) => s.trim()).filter(Boolean) : undefined,
+      engine: opts.engine,
+      max: opts.max,
+      deep: opts.deep,
+      headless: !opts.headed,
+      onProgress: (m) => console.error(`… ${m}`),
+    });
+    if (opts.json) {
+      console.log(JSON.stringify(scan, null, 2));
+      return;
+    }
+    const q = scan.query.advertiser ?? scan.query.companyId ?? scan.query.keyword;
+    console.log(`\n${q} — ${scan.fetched} ads via ${scan.engine}${scan.totalReported ? ` (library reports ${scan.totalReported} total)` : ""}`);
+    if (scan.note) console.log(scan.note);
+    console.log("");
+    scan.ads.forEach((a, i) => {
+      const d = a.detail;
+      const sponsor = a.promotedBy ? ` [${a.promotedBy}]` : "";
+      const fmt = (d?.format ?? a.format) ? ` {${d?.format ?? a.format}}` : "";
+      const ran = d?.ranFrom ? `  ran ${d.ranFrom}${d.ranTo && d.ranTo !== d.ranFrom ? `→${d.ranTo}` : ""}` : "";
+      const impr = d?.totalImpressions ? `  impr ${d.totalImpressions}` : "";
+      const geo = d?.impressionsByCountry?.length ? `  geo ${d.impressionsByCountry.slice(0, 3).map((c) => `${c.country} ${c.share}`).join(", ")}` : "";
+      console.log(`${String(i + 1).padStart(2)}. ${a.advertiser}${sponsor}${fmt}${ran}${impr}${geo}`);
+      const copy = (a.commentary ?? "").replace(/\s+/g, " ").trim();
+      if (copy) console.log(`    “${copy.slice(0, 180)}${copy.length > 180 ? "…" : ""}”`);
+      if (d?.targeting?.length) {
+        const tg = d.targeting
+          .map((t) => `${t.facet}: ${[...t.included, ...t.excluded.map((e) => `-${e}`)].join("/")}`)
+          .join("  ·  ");
+        console.log(`    🎯 ${tg}`);
+      }
+      console.log(`    ${a.detailUrl}`);
+    });
+    console.log(`\nReview the copy + formats + targeting + cadence above to synthesize messaging themes and how this account is run.`);
   });
 
 program

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "csv-parse": "^5.6.0",
     "open": "^10.1.0",
+    "playwright": "^1.61.0",
     "zod": "^3.24.1"
   }
 }

--- a/packages/core/src/adLibrary.ts
+++ b/packages/core/src/adLibrary.ts
@@ -1,0 +1,435 @@
+/// <reference lib="dom" />
+/**
+ * Competitor ad intelligence via the public LinkedIn Ad Library.
+ *
+ * This is the one part of Liam that does NOT use the authenticated Marketing
+ * API (which only ever sees your own ad accounts). The Ad Library
+ * (https://www.linkedin.com/ad-library) is public and shows every advertiser's
+ * live and recent ads. We render it with a headless browser because both the
+ * "see more" pagination and the per-ad transparency panel (run dates, impression
+ * ranges, country breakdown) are hydrated client-side and never appear in the
+ * raw HTML.
+ *
+ * Playwright is imported lazily so the rest of @liads/core stays importable in
+ * environments without a browser (e.g. the hosted Vercel MCP). Competitor
+ * scanning only works where a real Chrome/Chromium is available — locally.
+ */
+
+const AD_LIBRARY_BASE = "https://www.linkedin.com/ad-library";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+/** A single ad as shown on the Ad Library search results (card) level. */
+export interface AdLibraryCard {
+  detailId: string;
+  detailUrl: string;
+  /** Displayed name on the card. For thought-leader ads this is the person, not the sponsor. */
+  advertiser: string;
+  /** The "Promoted" / "Promoted by <company>" line, when present (identifies the real sponsor). */
+  promotedBy?: string;
+  /** The ad body copy (the post text). Absent for image-only ads. */
+  commentary?: string;
+  /** LinkedIn creative type, e.g. SPONSORED_STATUS_UPDATE, TEXT_AD, SPOTLIGHT_V2. */
+  format?: string;
+  imageUrl?: string;
+}
+
+/** Per-ad transparency data, from the ad's detail page (scraper) or the API. */
+export interface AdLibraryDetail {
+  format?: string;
+  /** Legal entity from "Paid for by ..." (API: advertiser.adPayer). */
+  paidForBy?: string;
+  /** Advertiser's LinkedIn page/profile URL (API only). */
+  advertiserUrl?: string;
+  /** The creative headline (distinct from the body copy). Scraper only. */
+  headline?: string;
+  /** Call-to-action button label, e.g. "Learn more", "Download". Scraper only. */
+  cta?: string;
+  /** First served date, "MMM D, YYYY" (scraper) or YYYY-MM-DD (API). EU-served ads only. */
+  ranFrom?: string;
+  /** Last served date. EU-served ads only. */
+  ranTo?: string;
+  /** Estimated total impressions range, e.g. "150k-200k" or "1k-5k". EU-served ads only. */
+  totalImpressions?: string;
+  /** Per-country impression share. EU-served ads only. */
+  impressionsByCountry?: { country: string; share: string }[];
+  /** Structured targeting facets the advertiser selected (API only). EU-served ads only. */
+  targeting?: { facet: string; included: string[]; excluded: string[] }[];
+}
+
+export type AdLibraryAd = AdLibraryCard & { detail?: AdLibraryDetail };
+
+export interface AdLibraryScanOptions {
+  /** Advertiser display name (accountOwner). */
+  advertiser?: string;
+  /** Numeric LinkedIn company id (companyIds). More precise than name. */
+  companyId?: string;
+  /** Free-text keyword search across ad copy. */
+  keyword?: string;
+  /** ISO-3166 country codes to scope the search, e.g. ["US", "GB"]. */
+  countries?: string[];
+  /** Max ads to collect (default 50). Big advertisers have thousands. */
+  max?: number;
+  /** Fetch each ad's detail page for run dates / impressions / targeting (default true). */
+  deep?: boolean;
+  /** Parallel detail-page fetches when deep (default 4). */
+  concurrency?: number;
+  /** Run the browser headless (default true). */
+  headless?: boolean;
+  /** Progress callback for long scans. */
+  onProgress?: (msg: string) => void;
+}
+
+export interface AdLibraryScan {
+  query: { advertiser?: string; companyId?: string; keyword?: string; countries?: string[]; url: string };
+  /** The "N ads" count the library reports for this advertiser, when shown. */
+  totalReported?: number;
+  /** How many ads we actually collected. */
+  fetched: number;
+  ads: AdLibraryAd[];
+}
+
+/**
+ * Turn a free-form competitor reference into structured scan options.
+ * Accepts: a numeric company id, a linkedin.com/company/<id> URL, an
+ * /ad-library/search?... URL (passed through), or a plain advertiser name.
+ */
+export function parseAdvertiserQuery(input: string): Partial<AdLibraryScanOptions> & { rawUrl?: string } {
+  const trimmed = input.trim();
+  if (/^\d+$/.test(trimmed)) return { companyId: trimmed };
+
+  // An ad-library search URL — pull its params back out.
+  const searchUrl = trimmed.match(/ad-library\/search\?(.+)$/);
+  if (searchUrl) {
+    const p = new URLSearchParams(searchUrl[1]);
+    const companyId = p.get("companyIds") ?? undefined;
+    const advertiser = p.get("accountOwner") ?? undefined;
+    const keyword = p.get("keyword") ?? undefined;
+    return { companyId, advertiser, keyword, rawUrl: trimmed };
+  }
+
+  // A company page URL with a numeric id.
+  const companyUrl = trimmed.match(/linkedin\.com\/company\/(\d+)/);
+  if (companyUrl) return { companyId: companyUrl[1] };
+
+  return { advertiser: trimmed };
+}
+
+/** Build the Ad Library search URL for a set of options. */
+export function buildSearchUrl(opts: AdLibraryScanOptions): string {
+  const url = new URL(`${AD_LIBRARY_BASE}/search`);
+  if (opts.companyId) url.searchParams.set("companyIds", opts.companyId);
+  if (opts.advertiser) url.searchParams.set("accountOwner", opts.advertiser);
+  if (opts.keyword) url.searchParams.set("keyword", opts.keyword);
+  if (opts.countries?.length) url.searchParams.set("countries", opts.countries.join(","));
+  return url.toString();
+}
+
+/** Lazily import Playwright and launch the system Chrome (no bundled-browser download needed). */
+async function launchBrowser(headless: boolean) {
+  let pw: typeof import("playwright");
+  try {
+    // webpackIgnore keeps the hosted (Next.js) bundle from trying to resolve
+    // playwright; it is only ever loaded locally when a scan actually runs.
+    pw = await import(/* webpackIgnore: true */ "playwright");
+  } catch {
+    throw new Error(
+      "Playwright is not installed. Run `pnpm -r install` in the linkedin-ads repo to enable competitor ad scanning.",
+    );
+  }
+  // Prefer the installed Google Chrome (channel) so we don't need a Chromium download.
+  try {
+    return await pw.chromium.launch({ channel: "chrome", headless });
+  } catch {
+    try {
+      return await pw.chromium.launch({ headless });
+    } catch (e) {
+      throw new Error(
+        "Could not launch a browser. Install Google Chrome, or run `npx playwright install chromium`. " +
+          (e instanceof Error ? e.message : String(e)),
+      );
+    }
+  }
+}
+
+/* ------------------------------ in-page parsers ----------------------------- */
+/* These functions are stringified and run inside the page via evaluate(), so
+   they must be self-contained (no closure over module scope). */
+
+function extractCardsInPage(): AdLibraryCard[] {
+  const text = (el: Element | null | undefined) => (el ? (el as HTMLElement).innerText.trim() : "");
+  const items = Array.from(document.querySelectorAll("li.search-result-item"));
+  const out: AdLibraryCard[] = [];
+  const seen = new Set<string>();
+  for (const li of items) {
+    const anchor = li.querySelector<HTMLAnchorElement>('a[href*="/ad-library/detail/"]');
+    const href = anchor?.getAttribute("href") ?? "";
+    const id = href.match(/detail\/(\d+)/)?.[1];
+    if (!id || id === "12345678" || seen.has(id)) continue;
+    seen.add(id);
+
+    const preview = li.querySelector("[data-creative-type]");
+    const promotedEl = Array.from(li.querySelectorAll(".text-color-text-secondary")).find((e) =>
+      /promot/i.test((e as HTMLElement).innerText),
+    );
+    const advEl =
+      li.querySelector(".text-color-text.font-bold") ||
+      li.querySelector('[class*="brand-lockup"]') ||
+      li.querySelector(".font-bold");
+    const img = li.querySelector<HTMLImageElement>("img[data-delayed-url], img[src]");
+
+    out.push({
+      detailId: id,
+      detailUrl: `https://www.linkedin.com/ad-library/detail/${id}`,
+      advertiser: text(advEl),
+      promotedBy: promotedEl ? text(promotedEl) : undefined,
+      commentary: text(li.querySelector(".commentary__content")) || undefined,
+      format: preview?.getAttribute("data-creative-type") ?? undefined,
+      imageUrl: img?.getAttribute("data-delayed-url") || img?.getAttribute("src") || undefined,
+    });
+  }
+  return out;
+}
+
+/** Parse a detail page's visible text + creative type into structured transparency fields. */
+export function parseDetail(innerText: string, creativeType?: string): AdLibraryDetail {
+  const detail: AdLibraryDetail = {};
+  if (creativeType) detail.format = creativeType;
+
+  const paid = innerText.match(/Paid for by\s+(.+)/);
+  if (paid?.[1]) detail.paidForBy = paid[1].trim();
+
+  const ran = innerText.match(/Ran from\s+(.+?)\s+to\s+(.+)/);
+  if (ran?.[1] && ran[2]) {
+    detail.ranFrom = ran[1].trim();
+    detail.ranTo = ran[2].trim();
+  } else {
+    const ranOne = innerText.match(/Ran on\s+(.+)/);
+    if (ranOne?.[1]) detail.ranFrom = detail.ranTo = ranOne[1].trim();
+  }
+
+  const impr = innerText.match(/Total Impressions\s*\n\s*([0-9][0-9.,kKmM+\s-]*)/);
+  if (impr?.[1]) detail.totalImpressions = impr[1].trim();
+
+  // Country lines come as "<country>\n<pct>%".
+  const countries: { country: string; share: string }[] = [];
+  const countryRe = /([A-Z][A-Za-z .'-]+)\n(\d+(?:\.\d+)?%)/g;
+  let m: RegExpExecArray | null;
+  while ((m = countryRe.exec(innerText))) {
+    const name = m[1]?.trim();
+    const share = m[2];
+    if (!name || !share || /impression|total|country|advertiser|paid/i.test(name)) continue;
+    countries.push({ country: name, share });
+  }
+  if (countries.length) detail.impressionsByCountry = countries;
+
+  return detail;
+}
+
+function extractDetailInPage(): { innerText: string; creativeType?: string; headline?: string; cta?: string } {
+  const preview = document.querySelector("[data-creative-type]");
+  const headlineEl =
+    document.querySelector(".sponsored-status-update-preview a[data-tracking-control-name*='headline']") ||
+    document.querySelector("[class*='headline']");
+  const ctaEl = document.querySelector("a[class*='cta'], button[class*='cta'], .ad-preview a[role='button']");
+  return {
+    innerText: (document.body as HTMLElement).innerText,
+    creativeType: preview?.getAttribute("data-creative-type") ?? undefined,
+    headline: headlineEl ? (headlineEl as HTMLElement).innerText.trim() : undefined,
+    cta: ctaEl ? (ctaEl as HTMLElement).innerText.trim() : undefined,
+  };
+}
+
+/** Ad copy + creative scraped from a single detail page. */
+export interface AdCopy {
+  commentary?: string;
+  imageUrl?: string;
+  headline?: string;
+  cta?: string;
+}
+
+function extractCopyInPage(): AdCopy {
+  const text = (el: Element | null) => (el ? (el as HTMLElement).innerText.trim() : undefined);
+  const img = document.querySelector<HTMLImageElement>(".ad-preview img[data-delayed-url], .ad-preview img[src]");
+  const preview = document.querySelector("[data-creative-type]");
+  const headlineEl =
+    (preview?.querySelector("a[data-tracking-control-name*='headline']") as Element | null) ||
+    document.querySelector("[class*='headline']");
+  const ctaEl = document.querySelector(".ad-preview a[role='button'], a[class*='cta'], button[class*='cta']");
+  return {
+    commentary: text(document.querySelector(".commentary__content")),
+    imageUrl: img?.getAttribute("data-delayed-url") || img?.getAttribute("src") || undefined,
+    headline: text(headlineEl),
+    cta: text(ctaEl),
+  };
+}
+
+/**
+ * Fetch ad copy/creative for a specific set of ad ids by opening each ad's
+ * public detail page. Used to layer copy onto the metadata the official API
+ * returns (which has no creative). Returns a map keyed by detail id; ids whose
+ * page fails are simply absent. Never throws for an individual page.
+ */
+export async function fetchAdCopyByIds(
+  detailIds: string[],
+  opts: { concurrency?: number; headless?: boolean; onProgress?: (m: string) => void } = {},
+): Promise<Map<string, AdCopy>> {
+  const out = new Map<string, AdCopy>();
+  if (!detailIds.length) return out;
+  const concurrency = Math.max(1, opts.concurrency ?? 4);
+  const headless = opts.headless ?? true;
+  const progress = opts.onProgress ?? (() => {});
+
+  const browser = await launchBrowser(headless);
+  try {
+    const ctx = await browser.newContext({ userAgent: DESKTOP_UA, viewport: { width: 1280, height: 1600 } });
+    let idx = 0;
+    let done = 0;
+    const worker = async () => {
+      while (idx < detailIds.length) {
+        const my = idx++;
+        const id = detailIds[my];
+        if (!id) continue;
+        const dp = await ctx.newPage();
+        try {
+          await dp.goto(`https://www.linkedin.com/ad-library/detail/${id}`, {
+            waitUntil: "domcontentloaded",
+            timeout: 45000,
+          });
+          await dp.waitForTimeout(1800);
+          const copy = (await dp.evaluate(extractCopyInPage)) as AdCopy;
+          if (copy.commentary || copy.imageUrl || copy.headline) out.set(id, copy);
+        } catch {
+          /* skip a flaky page */
+        } finally {
+          await dp.close().catch(() => {});
+          progress(`Copy ${++done}/${detailIds.length}`);
+        }
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(concurrency, detailIds.length) }, worker));
+    return out;
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+/* --------------------------------- the scan --------------------------------- */
+
+/**
+ * Collect a competitor's ads from the public LinkedIn Ad Library and (by
+ * default) enrich each with its transparency detail. Synthesis of themes is
+ * left to the caller — this returns clean structured data to analyze.
+ */
+export async function scanAdLibrary(opts: AdLibraryScanOptions): Promise<AdLibraryScan> {
+  if (!opts.advertiser && !opts.companyId && !opts.keyword) {
+    throw new Error("Provide an advertiser name, companyId, or keyword to scan.");
+  }
+  const max = opts.max ?? 50;
+  const deep = opts.deep ?? true;
+  const concurrency = Math.max(1, opts.concurrency ?? 4);
+  const headless = opts.headless ?? true;
+  const progress = opts.onProgress ?? (() => {});
+  const searchUrl = buildSearchUrl(opts);
+
+  const browser = await launchBrowser(headless);
+  try {
+    const ctx = await browser.newContext({ userAgent: DESKTOP_UA, viewport: { width: 1280, height: 1600 } });
+    const page = await ctx.newPage();
+    progress(`Opening ${searchUrl}`);
+    await page.goto(searchUrl, { waitUntil: "domcontentloaded", timeout: 45000 });
+    await page.waitForTimeout(2500);
+
+    // Total reported count, e.g. "9,081 ads".
+    let totalReported: number | undefined;
+    try {
+      const body = await page.evaluate(() => (document.body as HTMLElement).innerText);
+      const t = body.match(/([\d,]+)\s+ads?\b/i);
+      if (t?.[1]) totalReported = Number(t[1].replace(/,/g, ""));
+    } catch {
+      /* ignore */
+    }
+
+    // Scroll + "See more" until we hit `max` or the count stops growing.
+    const countCards = () =>
+      page.$$eval('a[href*="/ad-library/detail/"]', (as) => {
+        const ids = new Set<string>();
+        for (const a of as) {
+          const id = a.getAttribute("href")?.match(/detail\/(\d+)/)?.[1];
+          if (id && id !== "12345678") ids.add(id);
+        }
+        return ids.size;
+      });
+
+    let count = await countCards();
+    let stale = 0;
+    for (let i = 0; i < 80 && count < max && stale < 3; i++) {
+      await page.mouse.wheel(0, 24000);
+      await page.waitForTimeout(1200);
+      const btn = await page.$('button:has-text("See more"), button:has-text("Show more")');
+      if (btn) {
+        await btn.click().catch(() => {});
+        await page.waitForTimeout(1400);
+      }
+      const next = await countCards();
+      if (next <= count) stale++;
+      else stale = 0;
+      count = next;
+      progress(`Loaded ${count} ads...`);
+    }
+
+    let cards = (await page.evaluate(extractCardsInPage)) as AdLibraryCard[];
+    cards = cards.slice(0, max);
+    progress(`Collected ${cards.length} ad cards.`);
+
+    const ads: AdLibraryAd[] = cards.map((c) => ({ ...c }));
+
+    if (deep && ads.length) {
+      progress(`Fetching transparency detail for ${ads.length} ads (concurrency ${concurrency})...`);
+      let idx = 0;
+      const worker = async () => {
+        while (idx < ads.length) {
+          const my = idx++;
+          const ad = ads[my];
+          if (!ad) continue;
+          const dp = await ctx.newPage();
+          try {
+            await dp.goto(ad.detailUrl, { waitUntil: "domcontentloaded", timeout: 45000 });
+            await dp.waitForTimeout(2200);
+            const raw = (await dp.evaluate(extractDetailInPage)) as {
+              innerText: string;
+              creativeType?: string;
+              headline?: string;
+              cta?: string;
+            };
+            const detail = parseDetail(raw.innerText, raw.creativeType ?? ad.format);
+            if (raw.headline) detail.headline = raw.headline;
+            if (raw.cta) detail.cta = raw.cta;
+            ad.detail = detail;
+          } catch {
+            /* skip a flaky detail page; keep the card */
+          } finally {
+            await dp.close().catch(() => {});
+          }
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(concurrency, ads.length) }, worker));
+      progress("Detail fetch complete.");
+    }
+
+    return {
+      query: {
+        advertiser: opts.advertiser,
+        companyId: opts.companyId,
+        keyword: opts.keyword,
+        countries: opts.countries,
+        url: searchUrl,
+      },
+      totalReported,
+      fetched: ads.length,
+      ads,
+    };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}

--- a/packages/core/src/adLibraryApi.ts
+++ b/packages/core/src/adLibraryApi.ts
@@ -1,0 +1,199 @@
+/**
+ * Official LinkedIn Ad Library API client.
+ *
+ * Calls the vetted partner endpoint `GET /rest/adLibrary?q=criteria`
+ * (finder `partnerApiAdTransparencyCreativeEntities.FINDER-criteria`). Verified
+ * against live responses. The API returns rich, structured METADATA per ad:
+ *
+ *   {
+ *     adUrl, isRestricted,
+ *     details: {
+ *       type,                                  // ad format, e.g. SPONSORED_STATUS_UPDATE
+ *       advertiser: { advertiserName, adPayer, advertiserUrl },
+ *       adStatistics: {                        // EU-served ads only
+ *         firstImpressionAt, latestImpressionAt,   // epoch ms
+ *         totalImpressions: { from, to },
+ *         impressionsDistributionByCountry: [{ country: "urn:li:country:RO", impressionPercentage }]
+ *       },
+ *       adTargeting: [{ facetName, includedSegments, excludedSegments, isIncluded, isExcluded }]
+ *     }
+ *   }
+ *
+ * It does NOT return the ad creative copy/image — only the detail-page URL. Copy
+ * is layered in separately by the scraper (see competitorAds.ts).
+ *
+ * Confirmed `criteria` params: `keyword`, `advertiser` (name), `countries`
+ * (restli List of country URNs). There is no company-id or date-range param.
+ *
+ * ACCESS: vetted product. The app must be granted "LinkedIn Ad Library" in the
+ * Developer Portal; until then the endpoint returns 403 ACCESS_DENIED.
+ */
+
+import type { LinkedInClient } from "./http.js";
+import type { AdLibraryAd, AdLibraryDetail } from "./adLibrary.js";
+
+export interface AdLibraryApiOptions {
+  keyword?: string;
+  /** Advertiser display name (the only advertiser filter the API supports). */
+  advertiser?: string;
+  /** ISO-3166 country codes, e.g. ["US", "GB"] — converted to country URNs. */
+  countries?: string[];
+  /** Max ads to collect across pages (default 50). */
+  max?: number;
+}
+
+/** An ad enriched with the raw API element it was normalized from. */
+export type AdLibraryApiAd = AdLibraryAd & { raw?: unknown };
+
+export interface AdLibraryApiResult {
+  fetched: number;
+  /** The advertiser-wide total the API reports for this query. */
+  totalReported?: number;
+  ads: AdLibraryApiAd[];
+}
+
+/** Raised when the app isn't provisioned for the Ad Library product. */
+export class AdLibraryAccessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdLibraryAccessError";
+  }
+}
+
+/** Restli list literal of country URNs, e.g. List(urn:li:country:us,urn:li:country:gb). */
+const countryList = (codes: string[]) =>
+  `List(${codes.map((c) => `urn:li:country:${c.toLowerCase()}`).join(",")})`;
+
+const epochToDate = (ms: unknown): string | undefined => {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString().slice(0, 10);
+};
+
+const compactImpressions = (range: unknown): string | undefined => {
+  if (!range || typeof range !== "object") return undefined;
+  const r = range as { from?: number; to?: number };
+  const fmt = (n?: number) => (typeof n === "number" ? (n >= 1000 ? `${n / 1000}k` : String(n)) : "?");
+  if (r.from == null && r.to == null) return undefined;
+  return `${fmt(r.from)}-${fmt(r.to)}`;
+};
+
+const countryCode = (urn: unknown): string =>
+  typeof urn === "string" ? urn.replace(/^urn:li:country:/, "").toUpperCase() : String(urn ?? "");
+
+/** Normalize one live API element into our unified AdLibraryAd shape. */
+export function normalizeApiElement(el: Record<string, unknown>): AdLibraryApiAd {
+  const adUrl = typeof el.adUrl === "string" ? el.adUrl : "";
+  const detailId = adUrl.match(/detail\/(\d+)/)?.[1] ?? "";
+  const details = (el.details ?? {}) as Record<string, unknown>;
+  const advertiser = (details.advertiser ?? {}) as Record<string, unknown>;
+  const stats = details.adStatistics as Record<string, unknown> | undefined;
+  const targetingArr = Array.isArray(details.adTargeting) ? (details.adTargeting as Record<string, unknown>[]) : [];
+
+  const detail: AdLibraryDetail = {};
+  if (typeof details.type === "string") detail.format = details.type;
+  if (typeof advertiser.adPayer === "string") detail.paidForBy = advertiser.adPayer;
+  if (typeof advertiser.advertiserUrl === "string") detail.advertiserUrl = advertiser.advertiserUrl;
+
+  if (stats) {
+    const from = epochToDate(stats.firstImpressionAt);
+    const to = epochToDate(stats.latestImpressionAt);
+    if (from) detail.ranFrom = from;
+    if (to) detail.ranTo = to;
+    const impr = compactImpressions(stats.totalImpressions);
+    if (impr) detail.totalImpressions = impr;
+    const dist = stats.impressionsDistributionByCountry;
+    if (Array.isArray(dist)) {
+      detail.impressionsByCountry = dist
+        .map((c) => {
+          const o = c as Record<string, unknown>;
+          const pct = o.impressionPercentage;
+          return {
+            country: countryCode(o.country),
+            share: typeof pct === "number" ? `${pct.toFixed(1)}%` : String(pct ?? ""),
+          };
+        })
+        .filter((c) => c.country);
+    }
+  }
+
+  const targeting = targetingArr
+    .map((t) => ({
+      facet: typeof t.facetName === "string" ? t.facetName : "",
+      included: Array.isArray(t.includedSegments) ? (t.includedSegments as string[]) : [],
+      excluded: Array.isArray(t.excludedSegments) ? (t.excludedSegments as string[]) : [],
+    }))
+    // Keep only facets that actually carry segments (the API lists empty ones too).
+    .filter((t) => t.facet && (t.included.length || t.excluded.length));
+  if (targeting.length) detail.targeting = targeting;
+
+  return {
+    detailId,
+    detailUrl: adUrl || (detailId ? `https://www.linkedin.com/ad-library/detail/${detailId}` : ""),
+    advertiser: typeof advertiser.advertiserName === "string" ? advertiser.advertiserName : "",
+    promotedBy: typeof advertiser.adPayer === "string" ? advertiser.adPayer : undefined,
+    // The API has no copy/image; the scraper fills these in later (hybrid).
+    commentary: undefined,
+    format: typeof details.type === "string" ? details.type : undefined,
+    detail: Object.keys(detail).length ? detail : undefined,
+    raw: el,
+  };
+}
+
+/**
+ * Search the official Ad Library API, paging until `max` ads or exhaustion.
+ * Throws AdLibraryAccessError on 403 so the caller can fall back to the scraper.
+ */
+export async function searchAdLibraryApi(
+  client: LinkedInClient,
+  opts: AdLibraryApiOptions,
+): Promise<AdLibraryApiResult> {
+  if (!opts.advertiser && !opts.keyword) {
+    throw new Error(
+      "The Ad Library API filters by advertiser name or keyword (it has no company-id parameter). " +
+        "Provide `advertiser` or `keyword`.",
+    );
+  }
+  const max = opts.max ?? 50;
+  const ads: AdLibraryApiAd[] = [];
+  let start = 0;
+  let totalReported: number | undefined;
+  const pageSize = Math.min(100, max);
+
+  while (ads.length < max) {
+    const query: Record<string, string | number | undefined> = { q: "criteria", count: pageSize, start };
+    if (opts.keyword) query.keyword = opts.keyword;
+    if (opts.advertiser) query.advertiser = opts.advertiser;
+    if (opts.countries?.length) query.countries = countryList(opts.countries);
+
+    let res;
+    try {
+      res = await client.request<{
+        elements?: Record<string, unknown>[];
+        paging?: { total?: number };
+      }>({ path: "/adLibrary", query });
+    } catch (e) {
+      const err = e as { status?: number; message?: string };
+      if (err.status === 403) {
+        throw new AdLibraryAccessError(
+          "The Ad Library API is not provisioned for this app. Request the 'LinkedIn Ad Library' product " +
+            "in the Developer Portal (Products tab). " + (err.message ?? ""),
+        );
+      }
+      throw e;
+    }
+
+    if (totalReported === undefined && typeof res.data.paging?.total === "number") {
+      totalReported = res.data.paging.total;
+    }
+    const elements = res.data.elements ?? [];
+    if (!elements.length) break;
+    for (const el of elements) {
+      ads.push(normalizeApiElement(el));
+      if (ads.length >= max) break;
+    }
+    if (elements.length < pageSize) break;
+    start += pageSize;
+  }
+
+  return { fetched: ads.length, totalReported, ads };
+}

--- a/packages/core/src/competitorAds.ts
+++ b/packages/core/src/competitorAds.ts
@@ -1,0 +1,129 @@
+/**
+ * Unified competitor-ad scan.
+ *
+ * The official Ad Library API and the public-library scraper are complementary:
+ *   - API     → reliable, scalable METADATA: advertiser, payer, format, run
+ *               dates, impression ranges, per-country split, and structured
+ *               targeting facets — but NO ad copy/creative.
+ *   - Scraper → the ad COPY (and image), plus format/advertiser, from the public
+ *               library; needs a local browser.
+ *
+ * Engines (option `engine`):
+ *   - "auto" (default): query the API for metadata, then (deep) layer in copy by
+ *     scraping the same advertiser and joining on ad id. Falls back to a pure
+ *     scraper run if the API isn't provisioned / there's no auth.
+ *   - "api": API only — metadata, no copy. No browser; works on the hosted MCP.
+ *   - "scraper": browser only — copy + format + (EU) metadata. Local, no auth.
+ */
+
+import {
+  scanAdLibrary,
+  fetchAdCopyByIds,
+  type AdLibraryScanOptions,
+  type AdLibraryScan,
+  type AdLibraryAd,
+} from "./adLibrary.js";
+import { searchAdLibraryApi, AdLibraryAccessError } from "./adLibraryApi.js";
+
+export type CompetitorAdsEngine = "auto" | "api" | "scraper";
+
+export interface CompetitorAdsOptions extends AdLibraryScanOptions {
+  engine?: CompetitorAdsEngine;
+}
+
+export interface CompetitorAdsResult {
+  /** Which engine produced the result. */
+  engine: "api" | "scraper";
+  /** Notes, e.g. fallback reason or copy-enrichment coverage. */
+  note?: string;
+  query: { advertiser?: string; companyId?: string; keyword?: string; countries?: string[]; url?: string };
+  totalReported?: number;
+  fetched: number;
+  ads: AdLibraryAd[];
+}
+
+export async function scanCompetitorAds(opts: CompetitorAdsOptions): Promise<CompetitorAdsResult> {
+  const engine = opts.engine ?? "auto";
+  const progress = opts.onProgress ?? (() => {});
+  const deep = opts.deep ?? true;
+
+  // The API has no company-id filter; only advertiser name or keyword.
+  const apiUsable = Boolean(opts.advertiser || opts.keyword);
+
+  if (engine === "api" || (engine === "auto" && apiUsable)) {
+    try {
+      progress("Querying the official LinkedIn Ad Library API...");
+      const { createLiads } = await import("./client.js");
+      const liads = await createLiads();
+      const api = await searchAdLibraryApi(liads.client, {
+        keyword: opts.keyword,
+        advertiser: opts.advertiser,
+        countries: opts.countries,
+        max: opts.max,
+      });
+      const ads = api.ads as AdLibraryAd[];
+
+      let note: string | undefined;
+      if (deep && engine !== "api") {
+        // Layer in ad copy by opening each ad's own detail page (guaranteed
+        // coverage — the API and the public search list don't return the same
+        // ad sets, so joining on a search scrape would miss most ads).
+        try {
+          progress(`Layering in ad copy from ${ads.length} detail pages...`);
+          const copyById = await fetchAdCopyByIds(
+            ads.map((a) => a.detailId).filter(Boolean),
+            { concurrency: opts.concurrency, headless: opts.headless, onProgress: progress },
+          );
+          let enriched = 0;
+          for (const ad of ads) {
+            const c = copyById.get(ad.detailId);
+            if (c) {
+              if (c.commentary) ad.commentary = c.commentary;
+              if (c.imageUrl) ad.imageUrl = c.imageUrl;
+              if (c.headline && ad.detail) ad.detail.headline = c.headline;
+              if (c.cta && ad.detail) ad.detail.cta = c.cta;
+              enriched++;
+            }
+          }
+          note = `Copy layered onto ${enriched}/${ads.length} ads.`;
+        } catch (e) {
+          note = `Copy not layered in (${e instanceof Error ? e.message : String(e)}); API metadata only.`;
+          progress(note);
+        }
+      } else if (engine === "api") {
+        note = "API metadata only (engine=api); no ad copy.";
+      }
+
+      return {
+        engine: "api",
+        note,
+        query: { advertiser: opts.advertiser, companyId: opts.companyId, keyword: opts.keyword, countries: opts.countries },
+        totalReported: api.totalReported,
+        fetched: api.fetched,
+        ads,
+      };
+    } catch (e) {
+      if (engine === "api") throw e;
+      const reason =
+        e instanceof AdLibraryAccessError
+          ? "Ad Library API not provisioned for this app"
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      progress(`Official API unavailable (${reason}); falling back to the browser scraper.`);
+      const scan = await scanAdLibrary(opts);
+      return { engine: "scraper", note: `Used scraper fallback: ${reason}`, ...toResultBody(scan) };
+    }
+  }
+
+  // engine === "scraper", or "auto" with only a company id (API can't filter by id).
+  if (engine === "auto" && !apiUsable) {
+    progress("Only a company id was given; the API can't filter by id, using the browser scraper.");
+  }
+  const scan = await scanAdLibrary(opts);
+  return { engine: "scraper", ...toResultBody(scan) };
+}
+
+function toResultBody(scan: AdLibraryScan): Omit<CompetitorAdsResult, "engine" | "note"> {
+  return { query: scan.query, totalReported: scan.totalReported, fetched: scan.fetched, ads: scan.ads };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,3 +28,9 @@ export * from "./report.js";
 
 // Salesforce reader (Phase 3 foundation)
 export * from "./salesforce.js";
+
+// Competitor ad intelligence — official Ad Library API (preferred) with a
+// public-library browser scraper as fallback.
+export * from "./adLibrary.js";
+export * from "./adLibraryApi.js";
+export * from "./competitorAds.js";

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -167,6 +167,20 @@ export const SalesforceAudienceSchema = z.object({
 });
 export type SalesforceAudienceInput = z.infer<typeof SalesforceAudienceSchema>;
 
+export const AdLibraryScanSchema = z.object({
+  advertiser: z.string().optional().describe("Competitor/advertiser display name (accountOwner)"),
+  companyId: z.string().optional().describe("Numeric LinkedIn company id — more precise than name"),
+  keyword: z.string().optional().describe("Free-text keyword search across ad copy"),
+  countries: z.array(z.string()).optional().describe("ISO-3166 country codes to scope, e.g. ['US','GB']"),
+  max: z.number().int().positive().max(500).default(50).describe("Max ads to collect"),
+  engine: z.enum(["auto", "api", "scraper"]).default("auto").describe(
+    "auto = official API for metadata + scraper for copy (falls back to pure scraper if the API isn't provisioned); api = official API only, metadata no copy (works hosted); scraper = browser only (local, no auth)",
+  ),
+  deep: z.boolean().default(true).describe("auto: also layer in ad copy from the public library; scraper: fetch each ad's detail page for run dates / impressions / targeting"),
+  concurrency: z.number().int().positive().max(8).default(4).describe("Scraper: parallel detail-page fetches when deep"),
+});
+export type AdLibraryScanInput = z.infer<typeof AdLibraryScanSchema>;
+
 export const LaunchFromBriefSchema = z.object({
   accountId: z.string(),
   campaignGroupName: z.string(),

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -32,6 +32,8 @@ import {
   TextAdCreativeSchema,
   SponsoredImageCreativeSchema,
   LaunchFromBriefSchema,
+  scanCompetitorAds,
+  AdLibraryScanSchema,
 } from "@liads/core";
 
 const ok = (data: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] });
@@ -289,6 +291,20 @@ export function registerTools(server: McpServer): void {
       try {
         const liads = await createLiads();
         return ok(await launchFromBrief(liads, LaunchFromBriefSchema.parse(args)));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "inspect_competitor_ads",
+    "Pull a competitor's (or any company's) live and recent ads from the LinkedIn Ad Library. Prefers the official Ad Library API (engine 'auto'/'api'; works hosted but the app must be granted the 'LinkedIn Ad Library' product, else it 403s and 'auto' falls back to a local browser scraper — local only). Returns each ad's advertiser, sponsor ('promoted by'), full copy, format, image, and run dates / estimated impressions / per-country targeting (EU-served ads). Use to analyze messaging themes, offers, creative formats, posting cadence, and how their account is run. Name search is broad (includes partners/resellers); pass a numeric companyId for one company's own ads. Synthesize themes/trends rather than dumping ads raw.",
+    AdLibraryScanSchema.shape,
+    async (args) => {
+      try {
+        const q = AdLibraryScanSchema.parse(args);
+        return ok(await scanCompetitorAds(q));
       } catch (e) {
         return fail(e);
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.2.0
+      playwright:
+        specifier: ^1.61.0
+        version: 1.61.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -673,6 +676,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -856,6 +864,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -1514,6 +1532,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1665,6 +1686,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## What

Adds **competitor/company ad intelligence** — the first Liam capability that reads ads beyond Stan's own accounts. New MCP tool `inspect_competitor_ads` and CLI `liam competitor ads <advertiser>`.

The goal: pull a competitor's ads and synthesize messaging themes and **how their account is run**.

## How it works

The official **Ad Library API** and a **public-library scraper** are complementary, combined via `--engine` (default `auto`):

| engine | source | returns |
|---|---|---|
| `api` | `GET /rest/adLibrary?q=criteria` | Structured metadata: advertiser, payer (`adPayer`), format, and for **EU-served ads** run dates, impression ranges, per-country split, and targeting facets. No creative. Fast, headless, works on the hosted MCP. |
| `scraper` | Playwright via system Chrome | Ad **copy**/image the API omits. Local only; supports precise **company-id** search. |
| `auto` *(default)* | both | API metadata **+** copy layered from each ad's own detail page (joined by ad id for guaranteed coverage), falling back to a pure scraper run if the API isn't provisioned. |

## Notable details

- **API params**: `advertiser` (name), `keyword`, `countries` (ISO → country URNs). The API has **no company-id and no date-range filter** — for one company's own ads, use `--engine scraper` with a numeric id.
- **Copy coverage**: the API list (by relevance) and the public search list (by recency) return different ad sets, so copy is fetched from each ad's **own detail page by id** rather than an id-join against a search scrape.
- **Access**: the API is a vetted product ("LinkedIn Ad Library" in the Developer Portal); the app is provisioned. If revoked, `auto` 403s and falls back to the scraper.
- **Hosted safety**: `playwright` is lazy-imported and marked external in the Next.js app, so the hosted bundle never resolves it; impressions/targeting/dates are EU-only per LinkedIn's transparency rules.

## Testing

Verified live against HubSpot across all three engines: API metadata (run dates, `impr 1k-5k`, `geo AT/CH/DE`, `🎯 Language: English · Location: DACH`), full copy coverage (6/6) in `auto`, and scraper-by-company-id. Full workspace typecheck + build (incl. hosted web app) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)