### PR TITLE
Add change journal and lift comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
   company-id), and `auto` (default — API metadata + copy layered from each ad's detail page, falling
   back to the scraper if the API isn't provisioned). Search by `advertiser` name or `keyword` (the API
   has no company-id or date filter). CLI: `liam competitor ads`.
+- **Change journal & lift:** `log_ad_change` (record a change), `list_ad_changes`, `compute_lift`
+  (before-vs-after performance for each recorded change). Liam auto-journals every change it makes;
+  see [Change journal & lift](#change-journal--lift) below.
 
 ### Targeting spec
 
@@ -132,11 +135,36 @@ liam report summary [-p <period>]       # account rollup: totals, top performers
 liam report perf <level> [--parent <id>] # per-entity KPI rows
 liam report trend <level> <id> [-b weekly|monthly]  # trend with deltas
 liam launch --brief <brief.json>        # audience + group + campaign + draft creatives
+liam changelog list [-t <type>] [-i <id>]           # recorded ad changes, newest first
+liam changelog add -t <type> -i <id> -f <field> --after <v> [-l <label>]   # log a change made elsewhere
+liam lift <level> <id> [-w <days>]      # before-vs-after performance for each recorded change
 ```
 
 Periods: `last_7_days`, `last_30_days`, `last_90_days`, `month_to_date`, `last_month`.
 
 `--account` defaults to `defaultAccountId` from config where applicable.
+
+## Change journal & lift
+
+Liam keeps an append-only journal of every change made to an ad entity so you can measure the
+**lift** of a change: how performance differed in the window before it versus after.
+
+- **Where it lives:** `~/.liads/changelog.jsonl` (one JSON object per line). It's a plain local
+  file — no database, no account, no setup. Override the path with `LIADS_CHANGELOG_PATH`.
+- **Auto-capture:** every create/update Liam makes to a campaign group, campaign, or creative is
+  journaled automatically (captured at the one HTTP chokepoint, so it can't be forgotten).
+- **Manual entries:** log changes made outside Liam (e.g. in Campaign Manager), or attach a
+  hypothesis, with `liam changelog add` / the `log_ad_change` tool. Use `-l/--label` to name the
+  test (e.g. `"outcome-led headline test"`) and `--tags` to group related changes.
+- **Lift:** `liam lift <level> <entityId>` (or `compute_lift`) reads the journal for that entity
+  and, for each change, compares the `--window` days before (default 14) against the same window
+  after, reporting before/after KPIs and per-metric deltas (CTR, CPC, conversion rate,
+  cost-per-conversion, …). Recent changes get a clamped, `partial` after-window.
+
+This is a **directional pre/post comparison, not a controlled experiment** — it's confounded by
+seasonality, the LinkedIn learning phase after an edit, and any concurrent budget change. Read the
+deltas as a signal, not proof. Set `LIADS_NO_CHANGELOG=1` to disable auto-capture; journaling is
+also off on hosted deploys (read-only filesystem).
 
 ## Configuration
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,12 @@ import {
   resolveDateRange,
   scanCompetitorAds,
   parseAdvertiserQuery,
+  recordChange,
+  readChanges,
+  computeLift,
+  normalizeEntityType,
+  changelogPath,
+  LIFT_METRICS,
 } from "@liads/core";
 
 const program = new Command();
@@ -193,6 +199,100 @@ report
       const dc = p.deltas?.costUsd;
       const d = dc !== undefined ? ` (spend ${dc >= 0 ? "+" : ""}${pctf(dc)})` : "";
       console.log(`${p.periodStart}\t$${p.costUsd}\timpr ${p.impressions}\tCTR ${pctf(p.ctr)}\tconv ${p.conversions}${d}`);
+    }
+  });
+
+const fmtDelta = (x: number) => `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)}%`;
+const changelog = program.command("changelog").description("Local journal of ad changes (for lift comparison)");
+changelog
+  .command("add")
+  .description("Manually log a change (e.g. one made in Campaign Manager) to the journal")
+  .requiredOption("-t, --type <type>", "campaignGroup|campaign|creative")
+  .requiredOption("-i, --id <entityId>", "Entity id the change applies to")
+  .option("-f, --field <name>", "Name of the field that changed (e.g. dailyBudget, headline)")
+  .option("--before <value>", "Prior value of the field")
+  .option("--after <value>", "New value of the field")
+  .option("-n, --note <text>", "Freeform note instead of a field change")
+  .option("-l, --label <text>", "Hypothesis/label for this change (e.g. 'outcome-led headline test')")
+  .option("--name <name>", "Human name of the entity (for nicer listings)")
+  .option("--tags <list>", "Comma-separated tags")
+  .option("--at <iso>", "When the change took effect (ISO 8601); defaults to now")
+  .action(async (opts) => {
+    const type = normalizeEntityType(opts.type);
+    const tags = opts.tags ? String(opts.tags).split(",").map((s: string) => s.trim()).filter(Boolean) : undefined;
+    const isUpdate = Boolean(opts.field);
+    const event = await recordChange({
+      source: "manual",
+      kind: isUpdate ? "update" : "note",
+      entity: { type, id: opts.id, name: opts.name },
+      fields: isUpdate ? [{ field: opts.field, before: opts.before, after: opts.after }] : undefined,
+      summary: isUpdate ? `${opts.field} → ${opts.after ?? "(set)"}` : opts.note,
+      label: opts.label,
+      tags,
+      ts: opts.at,
+    });
+    console.log(`Logged ${event.id} — ${event.entity.type} ${event.entity.id}: ${event.summary ?? "(no summary)"}`);
+    console.log(`Journal: ${changelogPath()}`);
+  });
+changelog
+  .command("list")
+  .description("List recorded changes, newest first")
+  .option("-t, --type <type>", "Filter by campaignGroup|campaign|creative")
+  .option("-i, --id <entityId>", "Filter by entity id")
+  .option("--tag <tag>", "Filter by tag")
+  .option("-n, --limit <n>", "Max rows", (v) => parseInt(v, 10), 50)
+  .option("--json", "Print raw JSON")
+  .action(async (opts) => {
+    const type = opts.type ? normalizeEntityType(opts.type) : undefined;
+    const all = await readChanges({ type, id: opts.id, tag: opts.tag });
+    const rows = all.slice(0, opts.limit);
+    if (opts.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+    if (rows.length === 0) {
+      console.log(`No changes recorded yet. Journal: ${changelogPath()}`);
+      return;
+    }
+    for (const e of rows) {
+      const when = e.ts.slice(0, 16).replace("T", " ");
+      const who = e.source === "liam" ? "auto" : "man ";
+      const label = e.label ? `  «${e.label}»` : "";
+      console.log(`${when}  ${who}  ${e.entity.type}/${e.entity.id}  ${e.summary ?? e.kind}${label}`);
+    }
+    console.log(`\n${rows.length} of ${all.length} change(s). Run \`liam lift <level> <entityId>\` to measure performance lift.`);
+  });
+
+program
+  .command("lift <level> <entityId>")
+  .description("Compare performance before vs. after each recorded change to an entity (level: campaign_group|campaign|creative)")
+  .option("-w, --window <days>", "Days on each side of a change", (v) => parseInt(v, 10), 14)
+  .option("--json", "Print raw JSON")
+  .action(async (level, entityId, opts) => {
+    const type = normalizeEntityType(level);
+    const liads = await createLiads();
+    const lifts = await computeLift(liads.client, { type, entityId, windowDays: opts.window });
+    if (opts.json) {
+      console.log(JSON.stringify(lifts, null, 2));
+      return;
+    }
+    if (lifts.length === 0) {
+      console.log(`No recorded changes for ${type} ${entityId}. Log one with \`liam changelog add\`, or let Liam capture changes automatically.`);
+      return;
+    }
+    console.log(`Lift for ${type} ${entityId} — ${opts.window}d before vs. after each change`);
+    console.log(`(directional pre/post comparison; confounded by seasonality, learning phase, and budget changes)\n`);
+    for (const l of lifts) {
+      const when = l.change.ts.slice(0, 10);
+      const label = l.change.label ? ` «${l.change.label}»` : "";
+      console.log(`▸ ${when}  ${l.change.summary ?? l.change.kind}${label}`);
+      console.log(`    before ${l.before.start}…${l.before.end}   after ${l.after.start}…${l.after.end}${l.after.partial ? ` (partial, ${l.after.days}d)` : ""}`);
+      for (const k of LIFT_METRICS) {
+        const b = l.before.metrics[k] as number;
+        const a = l.after.metrics[k] as number;
+        console.log(`    ${k.padEnd(18)} ${String(b).padStart(10)} → ${String(a).padStart(10)}   ${fmtDelta(l.deltas[k] ?? 0)}`);
+      }
+      console.log("");
     }
   });
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -1,0 +1,320 @@
+import { randomUUID } from "node:crypto";
+import { appendFile, readFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { LIADS_DIR } from "./config.js";
+import type { LinkedInClient, MutationEvent } from "./http.js";
+import {
+  fetchAnalytics,
+  type AnalyticsPivot,
+  type DateRange,
+  type FilterType,
+  type LiDate,
+} from "./resources/analytics.js";
+import { aggregate, normalize, type MetricRow } from "./report.js";
+
+/**
+ * Change journal — an append-only, local record of every change made to an ad
+ * entity, so a later "lift" report can compare performance before vs. after a
+ * change. Stored as JSON Lines at ~/.liads/changelog.jsonl (one event per line):
+ * append-only writes are safe across concurrent runs, the file is greppable and
+ * diffable, and it needs no database. Changes Liam makes are captured
+ * automatically (see `recordMutation`); changes made elsewhere (e.g. in Campaign
+ * Manager) can be logged manually with `recordChange`.
+ *
+ * This is deliberately a local file, not a hosted store, so it works for any
+ * open-source user the moment they clone the repo — no account or token to set up.
+ */
+
+/** The three ad entities whose changes are worth tracking for lift. */
+export type AdEntityType = "campaignGroup" | "campaign" | "creative";
+
+export interface ChangedField {
+  field: string;
+  /** Prior value, when known (auto-capture of updates doesn't fetch the old value). */
+  before?: unknown;
+  after: unknown;
+}
+
+export interface ChangeEvent {
+  /** Stable id for this event. */
+  id: string;
+  /** ISO 8601 (UTC) timestamp the change took effect. */
+  ts: string;
+  /** Who/what made the change. */
+  source: "liam" | "manual";
+  /** create = entity made; update = field(s) changed; note = freeform annotation. */
+  kind: "create" | "update" | "note";
+  entity: { type: AdEntityType; id: string; name?: string; accountId?: string };
+  /** Field-level diffs (for updates). */
+  fields?: ChangedField[];
+  /** Human-readable one-liner describing the change. */
+  summary?: string;
+  /** Optional user hypothesis/label (e.g. "outcome-led headline test"). */
+  label?: string;
+  tags?: string[];
+}
+
+/** A change to record — id and ts are filled in by `recordChange` if omitted. */
+export type ChangeInput = Omit<ChangeEvent, "id" | "ts"> & { ts?: string };
+
+/* --------------------------------- storage ---------------------------------- */
+
+/** Path to the JSONL journal. Override with LIADS_CHANGELOG_PATH (e.g. for tests). */
+export function changelogPath(): string {
+  return process.env.LIADS_CHANGELOG_PATH ?? join(LIADS_DIR, "changelog.jsonl");
+}
+
+/**
+ * Append one change to the journal. Best-effort: a write failure (e.g. a
+ * read-only filesystem on a hosted deploy) is swallowed so it never breaks the
+ * mutation that triggered it. Returns the stored event (with id + ts filled in).
+ */
+export async function recordChange(input: ChangeInput): Promise<ChangeEvent> {
+  const { ts, ...rest } = input;
+  const event: ChangeEvent = { id: `chg_${randomUUID().slice(0, 8)}`, ts: ts ?? new Date().toISOString(), ...rest };
+  try {
+    const path = changelogPath();
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${JSON.stringify(event)}\n`, "utf8");
+  } catch {
+    /* journal is non-critical; never break the caller */
+  }
+  return event;
+}
+
+export interface ChangeFilter {
+  type?: AdEntityType;
+  id?: string;
+  tag?: string;
+  /** ISO timestamps, inclusive bounds. */
+  since?: string;
+  until?: string;
+}
+
+/** Read the journal back, newest first, optionally filtered. Empty if none yet. */
+export async function readChanges(filter?: ChangeFilter): Promise<ChangeEvent[]> {
+  let raw: string;
+  try {
+    raw = await readFile(changelogPath(), "utf8");
+  } catch {
+    return [];
+  }
+  const events = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => {
+      try {
+        return JSON.parse(l) as ChangeEvent;
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is ChangeEvent => e !== null)
+    .filter((e) => {
+      if (filter?.type && e.entity.type !== filter.type) return false;
+      if (filter?.id && e.entity.id !== filter.id) return false;
+      if (filter?.tag && !(e.tags ?? []).includes(filter.tag)) return false;
+      if (filter?.since && e.ts < filter.since) return false;
+      if (filter?.until && e.ts > filter.until) return false;
+      return true;
+    });
+  return events.sort((a, b) => b.ts.localeCompare(a.ts));
+}
+
+/* ------------------------------ auto-capture -------------------------------- */
+
+const COLLECTION_TYPE: Record<string, AdEntityType> = {
+  adCampaignGroups: "campaignGroup",
+  adCampaigns: "campaign",
+  creatives: "creative",
+};
+
+const TYPE_LABEL: Record<AdEntityType, string> = {
+  campaignGroup: "campaign group",
+  campaign: "campaign",
+  creative: "creative (ad)",
+};
+
+const fmtVal = (v: unknown): string =>
+  v === null || v === undefined ? "(none)" : typeof v === "object" ? JSON.stringify(v) : String(v);
+
+/**
+ * Translate a raw HTTP write into a structured change event, or null if it isn't
+ * one of the three tracked management endpoints. Creates are POSTs to a
+ * collection (id comes back in restliId); updates are POSTs to a specific id
+ * carrying a `patch.$set`. Anchored on the path tail so sibling endpoints (e.g.
+ * conversion association) are ignored.
+ */
+export function interpretMutation(m: MutationEvent): ChangeInput | null {
+  if (m.method === "GET" || m.status >= 300) return null;
+  const match = m.path.match(/\/adAccounts\/(\d+)\/(adCampaignGroups|adCampaigns|creatives)(?:\/([^/?]+))?$/);
+  if (!match) return null;
+  const [, accountId, collection, idSeg] = match;
+  const type = COLLECTION_TYPE[collection!]!;
+  const body = (m.body ?? {}) as Record<string, any>;
+
+  // Update: PARTIAL_UPDATE patch against an existing entity id.
+  const set = body?.patch?.$set as Record<string, unknown> | undefined;
+  if (idSeg && set && typeof set === "object") {
+    const fields: ChangedField[] = Object.entries(set).map(([field, after]) => ({ field, after }));
+    return {
+      source: "liam",
+      kind: "update",
+      entity: { type, id: idSeg, accountId },
+      fields,
+      summary: fields.map((f) => `${f.field} → ${fmtVal(f.after)}`).join(", "),
+    };
+  }
+
+  // Create: POST to the collection; the new id arrives in the x-restli-id header.
+  if (!idSeg) {
+    const id = m.restliId;
+    if (!id) return null;
+    const name: string | undefined = body?.name ?? body?.creative?.name;
+    return {
+      source: "liam",
+      kind: "create",
+      entity: { type, id, name, accountId },
+      summary: `Created ${TYPE_LABEL[type]}${name ? ` “${name}”` : ""}`,
+    };
+  }
+  return null;
+}
+
+/** The onMutation hook wired into the client: interpret a write and journal it. */
+export async function recordMutation(m: MutationEvent): Promise<void> {
+  const change = interpretMutation(m);
+  if (change) await recordChange(change);
+}
+
+/* ---------------------------------- lift ------------------------------------ */
+
+const PIVOT_FILTER: Record<AdEntityType, { pivot: AnalyticsPivot; filterType: FilterType }> = {
+  campaignGroup: { pivot: "CAMPAIGN_GROUP", filterType: "campaignGroups" },
+  campaign: { pivot: "CAMPAIGN", filterType: "campaigns" },
+  creative: { pivot: "CREATIVE", filterType: "creatives" },
+};
+
+const dayUTC = (d: Date) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+const addDays = (d: Date, n: number) => {
+  const x = new Date(d);
+  x.setUTCDate(x.getUTCDate() + n);
+  return x;
+};
+const toLiDate = (d: Date): LiDate => ({ year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() });
+const r4 = (x: number) => Math.round(x * 10000) / 10000;
+/** Relative change. Returns +1/-1 sentinels when the baseline is zero but the after isn't. */
+const pct = (after: number, before: number) => (before ? r4((after - before) / before) : after ? 1 : 0);
+
+/** The KPIs a lift report compares across a change boundary. */
+export const LIFT_METRICS = [
+  "impressions",
+  "clicks",
+  "costUsd",
+  "conversions",
+  "ctr",
+  "cpc",
+  "cvr",
+  "costPerConversion",
+] as const;
+
+export interface LiftWindow {
+  start: string; // YYYY-MM-DD
+  end: string; // YYYY-MM-DD
+  days: number;
+  /** True when the window was clamped (the change is too recent for a full after-window). */
+  partial: boolean;
+  metrics: MetricRow;
+}
+
+export interface ChangeLift {
+  change: ChangeEvent;
+  before: LiftWindow;
+  after: LiftWindow;
+  /** Relative change per metric (e.g. ctr 0.12 = +12%). */
+  deltas: Record<string, number>;
+}
+
+const isoDay = (d: LiDate) => `${d.year}-${String(d.month).padStart(2, "0")}-${String(d.day).padStart(2, "0")}`;
+
+async function windowMetrics(
+  client: LinkedInClient,
+  type: AdEntityType,
+  entityId: string,
+  range: DateRange,
+): Promise<MetricRow> {
+  const { pivot, filterType } = PIVOT_FILTER[type];
+  const raw = await fetchAnalytics(client, { pivot, timeGranularity: "ALL", dateRange: range, filterType, ids: [entityId] });
+  return aggregate(raw.map(normalize));
+}
+
+/**
+ * For each recorded change to an entity, compare performance in the `windowDays`
+ * before the change against the `windowDays` after. The after-window is clamped
+ * to today (flagged `partial`) when the change is too recent for a full window.
+ *
+ * This is a directional pre/post comparison, not a controlled experiment — it is
+ * confounded by seasonality, the LinkedIn learning phase after an edit, and any
+ * concurrent budget change. Read the deltas as a signal, not proof.
+ */
+export async function computeLift(
+  client: LinkedInClient,
+  opts: { type: AdEntityType; entityId: string; windowDays?: number; now?: Date; changes?: ChangeEvent[] },
+): Promise<ChangeLift[]> {
+  const windowDays = opts.windowDays ?? 14;
+  const today = dayUTC(opts.now ?? new Date());
+  const changes = opts.changes ?? (await readChanges({ type: opts.type, id: opts.entityId }));
+
+  const results: ChangeLift[] = [];
+  for (const change of changes) {
+    const changeDay = dayUTC(new Date(change.ts));
+    const beforeStart = addDays(changeDay, -windowDays);
+    const beforeEnd = addDays(changeDay, -1);
+    const fullAfterEnd = addDays(changeDay, windowDays - 1);
+    const afterEnd = fullAfterEnd > today ? today : fullAfterEnd;
+    const afterDays = Math.max(0, Math.round((afterEnd.getTime() - changeDay.getTime()) / 86400000) + 1);
+
+    const beforeRange: DateRange = { start: toLiDate(beforeStart), end: toLiDate(beforeEnd) };
+    const afterRange: DateRange = { start: toLiDate(changeDay), end: toLiDate(afterEnd) };
+
+    const before = await windowMetrics(client, opts.type, opts.entityId, beforeRange);
+    const after = afterDays > 0 ? await windowMetrics(client, opts.type, opts.entityId, afterRange) : aggregate([]);
+
+    const deltas: Record<string, number> = {};
+    for (const k of LIFT_METRICS) deltas[k] = pct(after[k] as number, before[k] as number);
+
+    results.push({
+      change,
+      before: { start: isoDay(beforeRange.start), end: isoDay(beforeRange.end), days: windowDays, partial: false, metrics: before },
+      after: {
+        start: isoDay(afterRange.start),
+        end: isoDay(afterRange.end),
+        days: afterDays,
+        partial: afterDays < windowDays,
+        metrics: after,
+      },
+      deltas,
+    });
+  }
+  return results;
+}
+
+/* -------------------------------- helpers ----------------------------------- */
+
+/** Map a report-style level ("campaign_group") or an entity type to AdEntityType. */
+export function normalizeEntityType(input: string): AdEntityType {
+  switch (input) {
+    case "campaign_group":
+    case "campaignGroup":
+    case "group":
+      return "campaignGroup";
+    case "campaign":
+      return "campaign";
+    case "creative":
+    case "ad":
+      return "creative";
+    default:
+      throw new Error(`Unknown entity type "${input}". Use campaignGroup | campaign | creative.`);
+  }
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "./config.js";
-import { LinkedInClient, type TokenProvider } from "./http.js";
+import { LinkedInClient, type MutationHook, type TokenProvider } from "./http.js";
 import { createTokenProvider } from "./auth.js";
+import { recordMutation } from "./changelog.js";
 
 export interface Liads {
   client: LinkedInClient;
@@ -15,6 +16,11 @@ export interface Liads {
 export async function createLiads(): Promise<Liads> {
   const config = await loadConfig();
   const getToken = await createTokenProvider();
-  const client = new LinkedInClient(config, getToken);
+  // Auto-journal every change to the local changelog for later lift comparison.
+  // Disabled on hosted deploys (read-only FS, identified by LIADS_REFRESH_TOKEN)
+  // and whenever LIADS_NO_CHANGELOG is set.
+  const journaling = !process.env.LIADS_REFRESH_TOKEN && !process.env.LIADS_NO_CHANGELOG;
+  const onMutation: MutationHook | undefined = journaling ? recordMutation : undefined;
+  const client = new LinkedInClient(config, getToken, onMutation);
   return { client, getToken };
 }

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -39,6 +39,26 @@ export interface ApiResponse<T> {
   headers: Headers;
 }
 
+/**
+ * A successful write (POST/PUT/DELETE) as seen at the HTTP layer. Emitted to an
+ * optional `onMutation` hook so callers can journal ad changes without every
+ * resource function having to opt in. Carries enough to reconstruct what changed:
+ * the path/method identify the entity + operation, `restliId` is the created id,
+ * and `body` holds the create payload or a PARTIAL_UPDATE `patch.$set`.
+ */
+export interface MutationEvent {
+  method: string;
+  path: string;
+  query?: RequestOptions["query"];
+  headers?: Record<string, string>;
+  body?: unknown;
+  status: number;
+  restliId?: string;
+}
+
+/** Side-effect hook invoked after a successful write. Must never throw. */
+export type MutationHook = (m: MutationEvent) => void | Promise<void>;
+
 /** Supplies a valid (auto-refreshed) bearer token. Implemented in auth.ts. */
 export type TokenProvider = () => Promise<string>;
 
@@ -64,6 +84,8 @@ export class LinkedInClient {
   constructor(
     private readonly config: AppConfig,
     private readonly getToken: TokenProvider,
+    /** Optional: notified after every successful write, for change journaling. */
+    private readonly onMutation?: MutationHook,
   ) {}
 
   async request<T = unknown>(opts: RequestOptions): Promise<ApiResponse<T>> {
@@ -120,10 +142,22 @@ export class LinkedInClient {
         throw new LinkedInApiError(message, res.status, data ?? text, serviceErrorCode);
       }
 
+      const restliId = res.headers.get("x-restli-id") ?? undefined;
+
+      // Journal writes (best-effort). A logging failure must never surface as a
+      // failed API call, so swallow everything the hook might throw or reject.
+      if (this.onMutation && method !== "GET") {
+        try {
+          await this.onMutation({ method, path: opts.path, query: opts.query, headers: opts.headers, body: opts.body, status: res.status, restliId });
+        } catch {
+          /* change journaling is non-critical */
+        }
+      }
+
       return {
         data: data as T,
         status: res.status,
-        restliId: res.headers.get("x-restli-id") ?? undefined,
+        restliId,
         headers: res.headers,
       };
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,9 @@ export * from "./orchestrate.js";
 export * from "./resources/analytics.js";
 export * from "./report.js";
 
+// Change journal + lift comparison (local JSONL store).
+export * from "./changelog.js";
+
 // Salesforce reader (Phase 3 foundation)
 export * from "./salesforce.js";
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -34,7 +34,14 @@ import {
   LaunchFromBriefSchema,
   scanCompetitorAds,
   AdLibraryScanSchema,
+  recordChange,
+  readChanges,
+  computeLift,
 } from "@liads/core";
+
+const AD_ENTITY_TYPE = z
+  .enum(["campaignGroup", "campaign", "creative"])
+  .describe("campaignGroup (the 'campaign'), campaign (the 'ad group'), or creative (the 'ad')");
 
 const ok = (data: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] });
 const fail = (e: unknown) => ({
@@ -291,6 +298,79 @@ export function registerTools(server: McpServer): void {
       try {
         const liads = await createLiads();
         return ok(await launchFromBrief(liads, LaunchFromBriefSchema.parse(args)));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "log_ad_change",
+    "Record a change to an ad entity in the local change journal, so a later lift report can compare performance before vs. after it. Liam logs its own changes automatically — use this for changes made elsewhere (e.g. in Campaign Manager) or to attach a hypothesis/label. Provide field+after for a field change, or note for a freeform annotation.",
+    {
+      entityType: AD_ENTITY_TYPE,
+      entityId: z.string().describe("Numeric id of the campaign group / campaign / creative"),
+      name: z.string().optional().describe("Human name of the entity (for nicer listings)"),
+      field: z.string().optional().describe("Field that changed, e.g. dailyBudget, headline, status"),
+      before: z.string().optional().describe("Prior value, if known"),
+      after: z.string().optional().describe("New value"),
+      note: z.string().optional().describe("Freeform note (used when there is no specific field)"),
+      label: z.string().optional().describe("Hypothesis/label, e.g. 'outcome-led headline test'"),
+      tags: z.array(z.string()).optional(),
+      at: z.string().optional().describe("ISO 8601 time the change took effect; defaults to now"),
+    },
+    async ({ entityType, entityId, name, field, before, after, note, label, tags, at }) => {
+      try {
+        const isUpdate = Boolean(field);
+        return ok(
+          await recordChange({
+            source: "manual",
+            kind: isUpdate ? "update" : "note",
+            entity: { type: entityType, id: entityId, name },
+            fields: isUpdate ? [{ field: field!, before, after }] : undefined,
+            summary: isUpdate ? `${field} → ${after ?? "(set)"}` : note,
+            label,
+            tags,
+            ts: at,
+          }),
+        );
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "list_ad_changes",
+    "List recorded ad changes (newest first) from the local change journal. Filter by entity type/id or tag. Use this to see what's been changed before computing lift.",
+    {
+      entityType: AD_ENTITY_TYPE.optional(),
+      entityId: z.string().optional(),
+      tag: z.string().optional(),
+      limit: z.number().int().positive().optional().describe("Max rows (default 50)"),
+    },
+    async ({ entityType, entityId, tag, limit }) => {
+      try {
+        const all = await readChanges({ type: entityType, id: entityId, tag });
+        return ok(all.slice(0, limit ?? 50));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "compute_lift",
+    "For each recorded change to an entity, compare performance in the window before the change against the window after it (default 14 days each side). Returns before/after KPI windows and per-metric relative deltas (CTR, CPC, conversion rate, cost-per-conversion, etc.). This is a directional pre/post comparison, NOT a controlled experiment — confounded by seasonality, the LinkedIn learning phase after edits, and concurrent budget changes; present it as a signal and call out partial after-windows on recent changes.",
+    {
+      entityType: AD_ENTITY_TYPE,
+      entityId: z.string(),
+      windowDays: z.number().int().positive().optional().describe("Days on each side of a change (default 14)"),
+    },
+    async ({ entityType, entityId, windowDays }) => {
+      try {
+        const liads = await createLiads();
+        return ok(await computeLift(liads.client, { type: entityType, entityId, windowDays }));
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
## What

Adds an append-only **change journal** and a **lift** report so you can measure how a change to an ad affected performance: before vs. after.

Chosen over a Notion-style external store because it has to be the open-source default — it needs no account, token, or schema setup. It matches Liam's existing file-based storage (`~/.liads`, plain JSON, no database).

## How it works

- **Auto-capture** — every create/update Liam makes to a campaign group, campaign, or creative is journaled automatically, hooked at the single HTTP chokepoint (`LinkedInClient` `onMutation`). Best-effort; a logging failure can never break a write.
- **Manual entries** — `liam changelog add` / `log_ad_change` for changes made in Campaign Manager, or to attach a hypothesis (`--label`).
- **Lift** — `liam lift <level> <entityId>` / `compute_lift` compares the `--window` days before each recorded change (default 14) against the same window after, reporting before/after KPIs and per-metric deltas (CTR, CPC, conversion rate, cost-per-conversion). Recent changes get a clamped, `partial` after-window.

It's surfaced everywhere as a **directional pre/post comparison, not a controlled experiment** — confounded by seasonality, the learning phase after an edit, and concurrent budget changes.

## Storage & toggles

- `~/.liads/changelog.jsonl`, one event per line. Override with `LIADS_CHANGELOG_PATH`.
- Disable auto-capture with `LIADS_NO_CHANGELOG=1`; automatically off on hosted deploys (read-only FS).

## Surface

- Core: new `packages/core/src/changelog.ts`; `onMutation` hook in `http.ts`; wired in `client.ts`.
- CLI: `changelog add`, `changelog list`, `lift`.
- MCP: `log_ad_change`, `list_ad_changes`, `compute_lift`.

## Testing

- `pnpm -r build` (per-package `tsc`) and the full web app compile clean.
- 12 unit assertions pass: mutation interpretation (create / update / ignoring sibling endpoints, GETs, failures), journal round-trip + filtering, and lift date-window math including the partial-after clamp.
- End-to-end CLI `add` → `list` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)