### PR TITLE
feat: list campaigns (drafts included), delete ads, retry transient createInline 404s

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,10 @@ import {
   normalizeEntityType,
   changelogPath,
   LIFT_METRICS,
+  listCampaignGroups,
+  listCampaigns,
+  listCreatives,
+  deleteAd,
 } from "@liads/core";
 
 const program = new Command();
@@ -366,6 +370,56 @@ program
     console.log(`  Creatives:      ${res.creativeIds.join(", ") || "(none)"}`);
     console.log(`  Review: ${res.links.campaign}`);
     res.warnings.forEach((w: string) => console.warn(`! ${w}`));
+  });
+
+const campaigns = program.command("campaigns").description("Account structure (campaign groups and ad groups), drafts included");
+campaigns
+  .command("list")
+  .description("List campaign groups and their ad groups, drafts included (unlike report perf)")
+  .option("--group <groupId>", "only ad groups in this campaign group")
+  .option("--all", "include archived/removed entities")
+  .option("--account <accountId>", "ad account id (defaults to config)")
+  .action(async (opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const groups = await listCampaignGroups(liads.client, accountId, { includeArchived: opts.all });
+    const list = await listCampaigns(liads.client, accountId, { groupId: opts.group, includeArchived: opts.all });
+    const groupName = new Map(groups.map((g) => [g.id, g.name]));
+    for (const g of groups) {
+      if (opts.group && g.id !== opts.group) continue;
+      console.log(`${g.id}\t${g.status}\t${g.name}`);
+      for (const c of list.filter((c) => c.campaignGroupId === g.id)) {
+        console.log(`  ${c.id}\t${c.status}\t${c.name}`);
+      }
+    }
+    const orphans = list.filter((c) => !groupName.has(c.campaignGroupId));
+    for (const c of orphans) console.log(`? ${c.id}\t${c.status}\t${c.name} (group ${c.campaignGroupId})`);
+  });
+
+const ad = program.command("ad").description("Individual ads (creatives)");
+ad
+  .command("list <campaignId>")
+  .description("List ads in an ad group, drafts included")
+  .option("--account <accountId>", "ad account id (defaults to config)")
+  .action(async (campaignId, opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const ads = await listCreatives(liads.client, accountId, campaignId);
+    if (ads.length === 0) {
+      console.log("No ads in this ad group.");
+      return;
+    }
+    for (const a of ads) console.log(`${a.id}\t${a.intendedStatus}\t${a.name || "(unnamed)"}`);
+  });
+ad
+  .command("delete <creativeId>")
+  .description("Delete an ad (creative + its Direct Sponsored Content post)")
+  .option("--account <accountId>", "ad account id (defaults to config)")
+  .action(async (creativeId, opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const res = await deleteAd(liads.client, accountId, creativeId);
+    console.log(`Deleted ${res.creativeId}` + (res.postUrn ? ` (post ${res.postUrn}${res.postDeleted ? " deleted" : " left in place"})` : ""));
   });
 
 program.parseAsync().catch((err) => {

--- a/packages/core/src/creative.ts
+++ b/packages/core/src/creative.ts
@@ -1,7 +1,8 @@
-import type { LinkedInClient, TokenProvider } from "./http.js";
+import { LinkedInApiError, type LinkedInClient, type TokenProvider } from "./http.js";
 import type { SponsoredImageCreativeInput } from "./schemas.js";
 import { uploadImage } from "./resources/images.js";
-import { createInlineImageCreative } from "./resources/creatives.js";
+import { createInlineImageCreative, deleteCreative, getCreative } from "./resources/creatives.js";
+import { creativeUrn } from "./urns.js";
 
 export interface DraftCreativeResult {
   creativeId: string;
@@ -39,19 +40,70 @@ export async function createSponsoredImageDraft(
     token,
   });
 
-  const created = await createInlineImageCreative(client, {
-    accountId: input.accountId,
-    campaignId: input.campaignId,
-    organizationUrn: input.organizationUrn,
-    commentary: input.commentary,
-    imageUrn,
-    headline: input.headline,
-    clickUri: input.clickUri,
-    callToAction: input.callToAction,
-    altText: input.headline,
-    intendedStatus: input.status,
-    name: input.name,
-  });
+  // createInline intermittently 404s ("Could not find entity") right after an
+  // image upload — asset propagation lag on LinkedIn's side. A short backoff
+  // and retry of the identical request succeeds.
+  const created = await withTransient404Retry(() =>
+    createInlineImageCreative(client, {
+      accountId: input.accountId,
+      campaignId: input.campaignId,
+      organizationUrn: input.organizationUrn,
+      commentary: input.commentary,
+      imageUrn,
+      headline: input.headline,
+      clickUri: input.clickUri,
+      callToAction: input.callToAction,
+      altText: input.headline,
+      intendedStatus: input.status,
+      name: input.name,
+    }),
+  );
 
   return { creativeId: created.id, status: input.status, imageUrn };
+}
+
+async function withTransient404Retry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastError = e;
+      if (!(e instanceof LinkedInApiError) || e.status !== 404 || i === attempts - 1) throw e;
+      await new Promise((r) => setTimeout(r, 3000 * (i + 1)));
+    }
+  }
+  throw lastError;
+}
+
+export interface DeletedAdResult {
+  creativeId: string;
+  postUrn?: string;
+  postDeleted: boolean;
+}
+
+/**
+ * Delete an ad: the creative and the Direct Sponsored Content post behind it.
+ * Post deletion is best-effort — a creative whose post is already gone still
+ * gets cleaned up.
+ */
+export async function deleteAd(
+  client: LinkedInClient,
+  accountId: string,
+  creativeId: string,
+): Promise<DeletedAdResult> {
+  const urn = creativeId.startsWith("urn:") ? creativeId : creativeUrn(creativeId);
+  const creative = await getCreative(client, accountId, urn);
+  const postUrn = (creative.content as { reference?: string } | undefined)?.reference;
+  await deleteCreative(client, accountId, urn);
+  let postDeleted = false;
+  if (postUrn) {
+    try {
+      await client.request({ method: "DELETE", path: `/posts/${encodeURIComponent(postUrn)}` });
+      postDeleted = true;
+    } catch {
+      // best-effort: the creative is gone either way
+    }
+  }
+  return { creativeId: urn, postUrn, postDeleted };
 }

--- a/packages/core/src/resources/campaignGroups.ts
+++ b/packages/core/src/resources/campaignGroups.ts
@@ -1,4 +1,5 @@
 import type { LinkedInClient } from "../http.js";
+import { searchAll } from "./search.js";
 import type { CampaignGroupInput } from "../schemas.js";
 import { sponsoredAccountUrn } from "../urns.js";
 
@@ -51,4 +52,29 @@ export async function setCampaignGroupStatus(
     headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
     body: { patch: { $set: { status } } },
   });
+}
+
+export interface CampaignGroupSummary {
+  id: string;
+  name: string;
+  status: string;
+}
+
+/**
+ * List ALL campaign groups on the account, drafts included. Performance
+ * reports only surface entities with analytics rows, which hides zero-spend
+ * drafts — this reads the account structure itself.
+ */
+export async function listCampaignGroups(
+  client: LinkedInClient,
+  accountId: string,
+  opts: { includeArchived?: boolean } = {},
+): Promise<CampaignGroupSummary[]> {
+  const els = await searchAll<{ id: number | string; name?: string; status?: string }>(
+    client,
+    `/adAccounts/${accountId}/adCampaignGroups`,
+  );
+  return els
+    .map((e) => ({ id: String(e.id), name: e.name ?? "", status: e.status ?? "" }))
+    .filter((g) => opts.includeArchived || !["ARCHIVED", "REMOVED"].includes(g.status));
 }

--- a/packages/core/src/resources/campaigns.ts
+++ b/packages/core/src/resources/campaigns.ts
@@ -1,4 +1,5 @@
 import type { LinkedInClient } from "../http.js";
+import { searchAll } from "./search.js";
 import type { CampaignInput } from "../schemas.js";
 import { sponsoredAccountUrn, campaignGroupUrn } from "../urns.js";
 import { buildTargetingCriteria, geoSegmentSpec, withDefaultExclusions } from "./targeting.js";
@@ -89,4 +90,44 @@ export async function setCampaignStatus(
     headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
     body: { patch: { $set: { status } } },
   });
+}
+
+export interface CampaignSummary {
+  id: string;
+  name: string;
+  status: string;
+  campaignGroupId: string;
+  format?: string;
+  objectiveType?: string;
+}
+
+/**
+ * List ALL campaigns ("ad groups") on the account, drafts included, optionally
+ * scoped to one campaign group. Reads account structure directly rather than
+ * analytics, so zero-spend drafts show up.
+ */
+export async function listCampaigns(
+  client: LinkedInClient,
+  accountId: string,
+  opts: { groupId?: string; includeArchived?: boolean } = {},
+): Promise<CampaignSummary[]> {
+  const els = await searchAll<{
+    id: number | string;
+    name?: string;
+    status?: string;
+    campaignGroup?: string;
+    format?: string;
+    objectiveType?: string;
+  }>(client, `/adAccounts/${accountId}/adCampaigns`);
+  return els
+    .map((e) => ({
+      id: String(e.id),
+      name: e.name ?? "",
+      status: e.status ?? "",
+      campaignGroupId: String(e.campaignGroup ?? "").replace("urn:li:sponsoredCampaignGroup:", ""),
+      format: e.format,
+      objectiveType: e.objectiveType,
+    }))
+    .filter((c) => opts.includeArchived || !["ARCHIVED", "REMOVED"].includes(c.status))
+    .filter((c) => !opts.groupId || c.campaignGroupId === opts.groupId);
 }

--- a/packages/core/src/resources/creatives.ts
+++ b/packages/core/src/resources/creatives.ts
@@ -156,3 +156,49 @@ export async function setCreativeStatus(
     body: { patch: { $set: { intendedStatus } } },
   });
 }
+
+export interface CreativeSummary {
+  id: string;
+  name: string;
+  intendedStatus: string;
+  campaignId: string;
+  postUrn?: string;
+}
+
+/** List creatives (ads) in a campaign, drafts included. */
+export async function listCreatives(
+  client: LinkedInClient,
+  accountId: string,
+  campaignId: string,
+): Promise<CreativeSummary[]> {
+  const res = await client.request({
+    path: `/adAccounts/${accountId}/creatives`,
+    rawQuery: `q=criteria&campaigns=List(${encodeURIComponent(campaignUrn(campaignId))})&pageSize=100`,
+  });
+  const els = (res.data as { elements?: Record<string, unknown>[] }).elements ?? [];
+  return els.map((e) => ({
+    id: String(e.id),
+    name: String(e.name ?? ""),
+    intendedStatus: String(e.intendedStatus ?? ""),
+    campaignId: String(e.campaign ?? "").replace("urn:li:sponsoredCampaign:", ""),
+    postUrn: (e.content as { reference?: string } | undefined)?.reference,
+  }));
+}
+
+export async function getCreative(client: LinkedInClient, accountId: string, creativeUrn: string) {
+  const res = await client.request({
+    path: `/adAccounts/${accountId}/creatives/${encodeURIComponent(creativeUrn)}`,
+  });
+  return res.data as Record<string, unknown>;
+}
+
+export async function deleteCreative(
+  client: LinkedInClient,
+  accountId: string,
+  creativeUrn: string,
+): Promise<void> {
+  await client.request({
+    method: "DELETE",
+    path: `/adAccounts/${accountId}/creatives/${encodeURIComponent(creativeUrn)}`,
+  });
+}

--- a/packages/core/src/resources/search.ts
+++ b/packages/core/src/resources/search.ts
@@ -1,0 +1,27 @@
+import type { LinkedInClient } from "../http.js";
+
+/**
+ * Drain a q=search finder that uses token pagination. LinkedIn's adAccounts
+ * sub-resources (adCampaignGroups, adCampaigns, ...) page via
+ * `metadata.nextPageToken` + `pageToken=` — the classic `start=` offset param
+ * is silently ignored and returns the same first page forever.
+ */
+export async function searchAll<T = Record<string, unknown>>(
+  client: LinkedInClient,
+  path: string,
+  opts: { pageSize?: number; maxPages?: number } = {},
+): Promise<T[]> {
+  const pageSize = opts.pageSize ?? 300;
+  const maxPages = opts.maxPages ?? 50;
+  const all: T[] = [];
+  let token: string | undefined;
+  for (let page = 0; page < maxPages; page++) {
+    const rawQuery = `q=search&pageSize=${pageSize}` + (token ? `&pageToken=${token}` : "");
+    const res = await client.request({ path, rawQuery });
+    const data = res.data as { elements?: T[]; metadata?: { nextPageToken?: string } };
+    all.push(...(data.elements ?? []));
+    token = data.metadata?.nextPageToken;
+    if (!token) break;
+  }
+  return all;
+}

--- a/packages/core/src/urns.ts
+++ b/packages/core/src/urns.ts
@@ -6,6 +6,7 @@ export const sponsoredAccountUrn = (id: string) => `urn:li:sponsoredAccount:${st
 export const campaignGroupUrn = (id: string) => `urn:li:sponsoredCampaignGroup:${stripPrefix(id)}`;
 export const campaignUrn = (id: string) => `urn:li:sponsoredCampaign:${stripPrefix(id)}`;
 export const adSegmentUrn = (id: string) => `urn:li:adSegment:${stripPrefix(id)}`;
+export const creativeUrn = (id: string) => `urn:li:sponsoredCreative:${stripPrefix(id)}`;
 
 export const idFromUrn = (urn: string) => stripPrefix(urn);
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -37,6 +37,10 @@ import {
   recordChange,
   readChanges,
   computeLift,
+  listCampaignGroups,
+  listCampaigns,
+  listCreatives,
+  deleteAd,
 } from "@liads/core";
 
 const AD_ENTITY_TYPE = z
@@ -162,6 +166,59 @@ export function registerTools(server: McpServer): void {
         const liads = await createLiads();
         const acct = accountId ?? (await requireDefaultAccountId());
         return ok(await listConversions(liads.client, acct));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "list_campaigns",
+    "List the account structure: campaign groups (campaigns) and/or their campaigns (ad groups), DRAFTS INCLUDED — unlike performance reports, which only show entities with spend. Pass level=groups for campaign groups only, level=campaigns for ad groups (optionally scoped by groupId), or level=both (default) for the full tree.",
+    {
+      accountId: z.string().optional(),
+      level: z.enum(["groups", "campaigns", "both"]).default("both"),
+      groupId: z.string().optional().describe("Scope campaigns to one campaign group id"),
+      includeArchived: z.boolean().default(false),
+    },
+    async ({ accountId, level, groupId, includeArchived }) => {
+      try {
+        const liads = await createLiads();
+        const acct = accountId ?? (await requireDefaultAccountId());
+        const out: Record<string, unknown> = {};
+        if (level !== "campaigns") out.groups = await listCampaignGroups(liads.client, acct, { includeArchived });
+        if (level !== "groups") out.campaigns = await listCampaigns(liads.client, acct, { groupId, includeArchived });
+        return ok(out);
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "list_ads",
+    "List the creatives (ads) in a campaign (ad group), drafts included: id, name, status, and backing post urn.",
+    { accountId: z.string().optional(), campaignId: z.string() },
+    async ({ accountId, campaignId }) => {
+      try {
+        const liads = await createLiads();
+        const acct = accountId ?? (await requireDefaultAccountId());
+        return ok(await listCreatives(liads.client, acct, campaignId));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "delete_ad",
+    "Delete an ad: removes the creative and (best-effort) the Direct Sponsored Content post behind it. Accepts a numeric creative id or a full urn:li:sponsoredCreative URN. Use for cleaning up drafts or replacing an ad whose copy must change (Campaign Manager's editor does not reflect post edits — recreate instead).",
+    { accountId: z.string().optional(), creativeId: z.string() },
+    async ({ accountId, creativeId }) => {
+      try {
+        const liads = await createLiads();
+        const acct = accountId ?? (await requireDefaultAccountId());
+        return ok(await deleteAd(liads.client, acct, creativeId));
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
Closes the operational gaps found while shipping the Q2 RIP ad batch. Everything that needed one-off scripts against the raw API this week is now a first-class Liam capability.

## New

| Capability | MCP tool | CLI |
|---|---|---|
| List campaign groups + ad groups, **drafts included** | `list_campaigns` (level: groups/campaigns/both, optional groupId) | `liam campaigns list [--group <id>] [--all]` |
| List ads in an ad group | `list_ads` | `liam ad list <campaignId>` |
| Delete an ad (creative + its DSC post, best-effort) | `delete_ad` | `liam ad delete <creativeId>` |

## Fixed

- `createSponsoredImageDraft` retries LinkedIn's transient createInline 404 ("Could not find entity" right after image upload, asset propagation lag) with 3s/6s backoff — batch runs no longer need external retry loops.
- New shared `searchAll` helper implements token pagination (`metadata.nextPageToken`); the `start=` offset param on these finders is silently ignored by LinkedIn and returns the first page forever.

## Why structure listing reads the API, not analytics

Performance reports only return entities with analytics rows, which hides zero-spend drafts — exactly the entities you need to see when staging a campaign (the Q2 RIP tree was invisible to `report perf`).

## Tested against the live account

- `liam campaigns list` shows the full Q2 RIP draft tree (5 competitor groups + persona ad groups)
- `liam ad list 859779956` shows the recreated draft ad
- Create-then-delete roundtrip in an unused ad group: creative deleted, post deleted, group left empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)