### PR TITLE
fix(creatives): URL-encode creative URN in setCreativeStatus

### DIFF
--- a/packages/core/src/resources/creatives.ts
+++ b/packages/core/src/resources/creatives.ts
@@ -149,9 +149,12 @@ export async function setCreativeStatus(
   creativeId: string,
   intendedStatus: "ACTIVE" | "PAUSED" | "DRAFT" | "ARCHIVED",
 ): Promise<void> {
+  // Accept a numeric id or a full URN; the URN's colons must be URL-encoded
+  // or LinkedIn rejects the path with "Syntax exception in path variables".
+  const urn = creativeId.startsWith("urn:") ? creativeId : `urn:li:sponsoredCreative:${creativeId}`;
   await client.request({
     method: "POST",
-    path: `/adAccounts/${accountId}/creatives/${creativeId}`,
+    path: `/adAccounts/${accountId}/creatives/${encodeURIComponent(urn)}`,
     headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
     body: { patch: { $set: { intendedStatus } } },
   });


### PR DESCRIPTION
The unencoded colons in urn:li:sponsoredCreative:... broke the request
path ('Syntax exception in path variables'), so activating an ad by URN
always failed. Accept a bare numeric id too.

Hit during the Q2 RIP publish; verified by activating all 35 ads.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
