### PR TITLE
Public-readiness docs + Ad Library rate-limit handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ pnpm -r typecheck
 
 - `packages/core` — LinkedIn REST client, OAuth, resource modules, audience hashing, Salesforce reader.
 - `packages/mcp` — MCP server. `src/tools.ts` registers tools; `src/index.ts` is the stdio entry.
-- `packages/cli` — the `liads` CLI.
+- `packages/cli` — the `liam` CLI.
 - `apps/web` — Next.js app hosting the MCP over HTTP (Vercel).
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -9,8 +9,24 @@ Manager.
 > Unofficial and not affiliated with or endorsed by LinkedIn.
 
 > Covers creation, matched audiences (including building one straight from Salesforce),
-> conversion selection, and performance reporting/insights. See [ROADMAP.md](./ROADMAP.md)
-> for what's shipped and what's planned next.
+> conversion selection, performance reporting/insights, competitor ad intelligence, and a
+> change journal with before/after lift. See [ROADMAP.md](./ROADMAP.md) for what's shipped
+> and what's planned next.
+
+## What using it looks like
+
+Once the MCP server is connected, you talk to your assistant in plain language:
+
+> "Launch a draft campaign targeting VPs of demand gen at US SaaS companies, $100/day,
+> using the Q3 accounts list from Salesforce."
+
+> "How did the retargeting campaign do last month vs the month before?"
+
+> "What ads is HubSpot running right now, and what offers are they pushing?"
+
+Liam resolves targeting facets, estimates reach, cleans and uploads the audience, creates
+the campaign group, campaign, and creatives as drafts, and reports back the ids. The same
+capabilities are available as `liam` CLI commands for scripted or batch use.
 
 ## Hierarchy mapping (LinkedIn differs from Google/Meta)
 
@@ -27,6 +43,24 @@ Manager.
 - `@liads/mcp` — MCP server (stdio for local; reused by the hosted app). **Primary interface.**
 - `@liads/cli` — the `liam` CLI over the same core, for scripted batch runs.
 - `@liads/web` — Next.js app that hosts the MCP over HTTP on Vercel.
+
+## How it works
+
+Both interfaces are thin layers over the same engine. Every MCP tool and CLI command builds
+a client via `createLiads()` (`core/src/client.ts`), which loads config plus an
+auto-refreshing OAuth token provider, then calls a typed resource module
+(`campaigns.ts`, `audience.ts`, `report.ts`, ...) that wraps LinkedIn's versioned REST API
+(`LinkedIn-Version` pinned in config). Input shapes live as zod schemas in
+`core/src/schemas.ts` and are reused verbatim as the MCP tool input schemas, so the CLI and
+MCP can never drift apart.
+
+The draft-only safety rule is enforced at creation: campaign groups, campaigns, and
+creatives are all written with `DRAFT` status, and there is deliberately no "activate"
+tool or command. Every write also passes through one HTTP chokepoint that appends to a
+local change journal (`~/.liads/changelog.jsonl`) for later lift analysis.
+
+[AGENTS.md](./AGENTS.md) has the full architecture notes and the LinkedIn API gotchas
+(restli encoding, required fields, DMP audience flow) learned from live testing.
 
 ## Prerequisites (everyone needs their own LinkedIn app)
 
@@ -88,7 +122,11 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
 - **Conversions:** `list_conversions` (select an existing insight-tag conversion to track).
   `create_campaign` and `launch_from_brief` accept `conversionIds` or `conversionName`, and
   fall back to `defaultConversionName` from config.
-- **Campaigns:** `create_campaign_group`, `create_campaign`, `create_text_ad`, `create_image_ad`
+- **Campaigns:** `create_campaign_group`, `create_campaign`, `create_text_ad`, `create_image_ad`;
+  `list_campaigns` (the account structure — campaign groups and their ad groups, **drafts
+  included**, unlike reporting which only shows entities with spend), `list_ads`, `delete_ad`
+  (removes the creative and best-effort its Direct Sponsored Content post). LinkedIn's editor
+  ignores post edits on a live ad, so to change copy you recreate: `delete_ad` + `create_image_ad`.
 - **Orchestrator:** `launch_from_brief` (audience + group + campaign + draft creatives in one call)
 - **Reporting:** `performance_summary` (account rollup + top/bottom + flags), `get_performance`
   (per-entity KPIs at any level), `performance_trend` (weekly/monthly with deltas). KPIs: CTR,
@@ -131,10 +169,16 @@ liam audience upload -n <name> -f <csv> --dry-run   # preview the cleaned CSV, n
 liam audience from-salesforce -n <name> -q "<SOQL>"   # Salesforce query -> matched audience
 liam audience status <segmentId>        # matching status + resolved size
 liam conversions list                   # account conversions (pick one to track)
+liam campaigns list [--group <id>] [--all]   # campaign groups + ad groups, drafts included
+liam ad list <campaignId>               # ads in an ad group (id, status, name), drafts included
+liam ad delete <creativeId>             # delete an ad (creative + its DSC post)
 liam report summary [-p <period>]       # account rollup: totals, top performers, flags
 liam report perf <level> [--parent <id>] # per-entity KPI rows
 liam report trend <level> <id> [-b weekly|monthly]  # trend with deltas
 liam launch --brief <brief.json>        # audience + group + campaign + draft creatives
+liam competitor ads <advertiser>        # any company's ads from the public Ad Library
+                                        #   <advertiser> = name, company id, or company URL
+                                        #   -k <keyword> -c <countries> -e auto|api|scraper -m <max> --json
 liam changelog list [-t <type>] [-i <id>]           # recorded ad changes, newest first
 liam changelog add -t <type> -i <id> -f <field> --after <v> [-l <label>]   # log a change made elsewhere
 liam lift <level> <id> [-w <days>]      # before-vs-after performance for each recorded change

--- a/packages/core/src/adLibrary.ts
+++ b/packages/core/src/adLibrary.ts
@@ -296,7 +296,12 @@ export async function fetchAdCopyByIds(
             waitUntil: "domcontentloaded",
             timeout: 45000,
           });
-          await dp.waitForTimeout(1800);
+          // The creative hydrates client-side; wait for the copy/preview to
+          // appear rather than a fixed delay (a fixed wait missed slow pages).
+          await dp
+            .waitForSelector(".commentary__content, [data-creative-type]", { timeout: 9000 })
+            .catch(() => {});
+          await dp.waitForTimeout(400);
           const copy = (await dp.evaluate(extractCopyInPage)) as AdCopy;
           if (copy.commentary || copy.imageUrl || copy.headline) out.set(id, copy);
         } catch {

--- a/packages/core/src/adLibraryApi.ts
+++ b/packages/core/src/adLibraryApi.ts
@@ -40,7 +40,16 @@ export interface AdLibraryApiOptions {
   countries?: string[];
   /** Max ads to collect across pages (default 50). */
   max?: number;
+  /** Delay between pages to respect the per-minute rate limit (default 2200ms). */
+  pageDelayMs?: number;
+  onProgress?: (m: string) => void;
 }
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const isThrottle = (e: unknown): boolean => {
+  const err = e as { status?: number; message?: string };
+  return err?.status === 429 || /throttl/i.test(err?.message ?? "");
+};
 
 /** An ad enriched with the raw API element it was normalized from. */
 export type AdLibraryApiAd = AdLibraryAd & { raw?: unknown };
@@ -154,10 +163,13 @@ export async function searchAdLibraryApi(
     );
   }
   const max = opts.max ?? 50;
+  const pageDelayMs = opts.pageDelayMs ?? 2200;
+  const progress = opts.onProgress ?? (() => {});
   const ads: AdLibraryApiAd[] = [];
   let start = 0;
   let totalReported: number | undefined;
-  const pageSize = Math.min(100, max);
+  // The criteria finder caps `count` at 25 per page; paginate via `start`.
+  const pageSize = Math.min(25, max);
 
   while (ads.length < max) {
     const query: Record<string, string | number | undefined> = { q: "criteria", count: pageSize, start };
@@ -166,20 +178,30 @@ export async function searchAdLibraryApi(
     if (opts.countries?.length) query.countries = countryList(opts.countries);
 
     let res;
-    try {
-      res = await client.request<{
-        elements?: Record<string, unknown>[];
-        paging?: { total?: number };
-      }>({ path: "/adLibrary", query });
-    } catch (e) {
-      const err = e as { status?: number; message?: string };
-      if (err.status === 403) {
-        throw new AdLibraryAccessError(
-          "The Ad Library API is not provisioned for this app. Request the 'LinkedIn Ad Library' product " +
-            "in the Developer Portal (Products tab). " + (err.message ?? ""),
-        );
+    // The Ad Library API is rate-limited per minute. On a throttle, wait out the
+    // window and retry the same page (a few times) rather than failing the pull.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        res = await client.request<{
+          elements?: Record<string, unknown>[];
+          paging?: { total?: number };
+        }>({ path: "/adLibrary", query });
+        break;
+      } catch (e) {
+        const err = e as { status?: number; message?: string };
+        if (err.status === 403) {
+          throw new AdLibraryAccessError(
+            "The Ad Library API is not provisioned for this app. Request the 'LinkedIn Ad Library' product " +
+              "in the Developer Portal (Products tab). " + (err.message ?? ""),
+          );
+        }
+        if (isThrottle(e) && attempt < 5) {
+          progress(`Rate limited; waiting 60s before retrying (have ${ads.length}/${max})...`);
+          await sleep(60_000);
+          continue;
+        }
+        throw e;
       }
-      throw e;
     }
 
     if (totalReported === undefined && typeof res.data.paging?.total === "number") {
@@ -193,6 +215,8 @@ export async function searchAdLibraryApi(
     }
     if (elements.length < pageSize) break;
     start += pageSize;
+    progress(`Fetched ${ads.length}/${Math.min(max, totalReported ?? max)} ads...`);
+    if (pageDelayMs) await sleep(pageDelayMs);
   }
 
   return { fetched: ads.length, totalReported, ads };

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -15,8 +15,8 @@ import type { TokenProvider } from "./http.js";
 const AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization";
 const TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken";
 
-/** Scopes for ad management. r_ads_reporting is for Phase 2 analytics. */
-export const DEFAULT_SCOPES = ["rw_ads", "r_ads_reporting"];
+/** Scopes for ad management. r_ads_reporting is for Phase 2 analytics. rw_conversions is for the Conversions API. */
+export const DEFAULT_SCOPES = ["rw_ads", "r_ads_reporting", "rw_conversions"];
 
 const CALLBACK_PORT = 53682;
 

--- a/packages/core/src/competitorAds.ts
+++ b/packages/core/src/competitorAds.ts
@@ -60,6 +60,7 @@ export async function scanCompetitorAds(opts: CompetitorAdsOptions): Promise<Com
         advertiser: opts.advertiser,
         countries: opts.countries,
         max: opts.max,
+        onProgress: progress,
       });
       const ads = api.ads as AdLibraryAd[];
 


### PR DESCRIPTION
## What

Two things, in separate commits:

**1. `feat(adLibrary)`** — commits the working-tree improvements that were sitting uncommitted locally (they build and typecheck cleanly, and the CLI + MCP were smoke-tested live with them):
- Retry Ad Library API pages on 429/throttle instead of failing the whole pull, with progress messages surfaced to the CLI/MCP.
- Fix pagination: the criteria finder caps `count` at 25 per page (was requesting 100 and silently getting less).
- Scraper waits for the creative to hydrate (`waitForSelector`) instead of a fixed 1.8s delay.
- Add `rw_conversions` to default OAuth scopes.

**2. `docs`** — make the repo legible to someone landing on it cold:
- README: new "What using it looks like" section (example prompts) and "How it works" section (shared core, zod schemas as single source of truth for CLI + MCP inputs, draft-only enforcement with no activate tool, change-journal chokepoint), linking to AGENTS.md for the deep API notes.
- README: document the newer surface that was missing from the tools list and CLI reference: `list_campaigns` / `list_ads` / `delete_ad`, `campaigns list`, `ad list` / `ad delete`, `competitor ads`.
- CONTRIBUTING: fix stale CLI name (`liads` → `liam`).

## Verified

- `pnpm -r build` and `pnpm -r typecheck` pass across all four packages.
- CLI live: `liam accounts list` returns real accounts; all commands present in help.
- MCP stdio live: `initialize` → `tools/list` (24 tools) → `tools/call list_ad_accounts` returns real data.
- Tracked files scanned: no secrets, tokens, account ids, or personal paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)