### PR TITLE
Document the two ways to use Liam: CLI and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,44 @@ Manager.
 > change journal with before/after lift. See [ROADMAP.md](./ROADMAP.md) for what's shipped
 > and what's planned next.
 
-## What using it looks like
+## What you can do with it
 
-Once the MCP server is connected, you talk to your assistant in plain language:
+Once Liam is connected, you talk to your assistant in plain language. Real requests it
+handles today, roughly in the order a campaign comes together:
 
-> "Launch a draft campaign targeting VPs of demand gen at US SaaS companies, $100/day,
-> using the Q3 accounts list from Salesforce."
+- "How many VPs of demand gen at US SaaS companies can we reach?" (resolves targeting
+  facets, estimates reach before any money is involved)
+- "Upload this CSV as a matched audience." (auto-cleans columns, hashes emails, converts
+  company domains to URLs)
+- "Build an audience from Salesforce: every contact on an account flagged as a target."
+  (SOQL straight to a matched audience)
+- "Launch a draft campaign for that audience, $100/day, tracking the demo-booked
+  conversion." (campaign group + campaign + draft ads in one call)
+- "What ads is HubSpot running right now, and what offers are they pushing?" (reads the
+  public Ad Library: copy, formats, and EU targeting metadata for any company)
+- "How did retargeting do last month vs the month before?" (trend report with deltas)
+- "Which ads should I pause this week?" (account rollup with top/bottom performers and
+  flags)
+- "Rewrite the copy on the losing ad." (delete + recreate as a fresh draft; LinkedIn
+  ignores edits to a live ad's post)
+- "Did the new headline actually help?" (change journal + before/after lift)
 
-> "How did the retargeting campaign do last month vs the month before?"
+Liam resolves the details, does the work, and reports back the ids. Every capability is
+also a `liam` CLI command for scripted or batch use.
 
-> "What ads is HubSpot running right now, and what offers are they pushing?"
+### Put it on a loop
 
-Liam resolves targeting facets, estimates reach, cleans and uploads the audience, creates
-the campaign group, campaign, and creatives as drafts, and reports back the ids. The same
-capabilities are available as `liam` CLI commands for scripted or batch use.
+Liam has no scheduler of its own, and doesn't need one: the client you drive it from does.
+Some loops that work well:
+
+- "Every Monday at 9am, pull last week's performance summary, compare it to the week
+  before, and flag anything that moved more than 20%." (a Claude Code scheduled agent)
+- "Every Friday, check what new ads our top three competitors shipped this week and
+  summarize the angles."
+- "Check the audience match status every few hours and tell me when it clears 300
+  members." (the minimum for a matched audience to serve)
+- Or skip the assistant entirely and put the CLI in cron:
+  `0 9 * * 1 liam report summary -p last_7_days`
 
 ## Hierarchy mapping (LinkedIn differs from Google/Meta)
 
@@ -62,51 +86,161 @@ local change journal (`~/.liads/changelog.jsonl`) for later lift analysis.
 [AGENTS.md](./AGENTS.md) has the full architecture notes and the LinkedIn API gotchas
 (restli encoding, required fields, DMP audience flow) learned from live testing.
 
-## Prerequisites (everyone needs their own LinkedIn app)
+## Get started
 
-1. Create a developer app at https://www.linkedin.com/developers/apps and request the
-   **Advertising API** product. (The **Audiences** product, needed for CSV audience upload,
-   is requested separately.)
-2. Add an OAuth **redirect URL** of `http://localhost:53682/callback` for local login.
+There are two ways to use Liam: as a CLI in your terminal, or as an MCP server your
+assistant talks to. Both run against **your own LinkedIn developer app**, so your
+credentials and your ad account stay yours. Both start with the same step 0.
 
-## Option A — Run locally (self-host, free)
+### Step 0: create a LinkedIn app (once)
+
+1. Create an app at https://www.linkedin.com/developers/apps. It must be associated
+   with your company's LinkedIn Page.
+2. On the **Products** tab, request access:
+
+   | Product | Needed for | Required? |
+   | --- | --- | --- |
+   | Advertising API | campaigns, ads, targeting, reporting, conversions | **Yes** |
+   | Audiences | uploading CSV contact/company lists as matched audiences | Only for audience upload |
+   | LinkedIn Ad Library | competitor ad metadata via the official API | Optional (the browser scraper works without it) |
+
+3. On the **Auth** tab, add `http://localhost:53682/callback` as an authorized redirect
+   URL, and note your **Client ID** and **Client Secret**.
+4. Once the Advertising API is approved, map your ad account under
+   **Products → Advertising API → View Ad Accounts**. Skip this and `accounts list`
+   comes back empty.
+
+**OAuth scopes.** `liam auth login` requests `rw_ads` (create and edit campaigns),
+`r_ads_reporting` (reporting), `rw_conversions` (conversion tracking), and
+`w_organization_social` (image ads create a post owned by your LinkedIn Page). If you add
+a product or scope later, run `auth login` again; a token refresh keeps only the scopes
+you originally granted.
+
+### Path 1: the CLI
 
 ```bash
-pnpm install
-pnpm -r build
+git clone https://github.com/stan-default/liam.git
+cd liam
+pnpm install && pnpm -r build
 
 # App credentials (alternatively set LIADS_CLIENT_ID / LIADS_CLIENT_SECRET env vars)
 mkdir -p ~/.liads
 echo '{ "clientId": "...", "clientSecret": "...", "linkedinVersion": "202605" }' > ~/.liads/config.json
 
-node packages/cli/dist/index.js auth login     # opens browser, stores tokens in ~/.liads
-node packages/cli/dist/index.js accounts list   # verify
-node packages/cli/dist/index.js launch --brief examples/brief.json
+node packages/cli/dist/index.js auth login      # opens the browser; tokens land in ~/.liads
+node packages/cli/dist/index.js accounts list   # verify, then set defaultAccountId in config.json
 ```
 
-Register the local MCP server with Claude (Desktop / Code):
+To get a global `liam` command instead of the long `node` path:
+
+```bash
+cd packages/cli && pnpm link --global
+liam accounts list
+```
+
+(No pnpm? An alias works too: `alias liam="node /abs/path/liam/packages/cli/dist/index.js"`.)
+
+A sensible first session:
+
+```bash
+liam targeting search titles "demand generation"   # resolve targeting URNs
+liam report summary -p last_30_days                # account rollup + flags
+liam launch --brief examples/brief.json            # creates DRAFTS only
+```
+
+The full [CLI reference](#cli-reference) is below.
+
+### Path 2: MCP (talk to it from your assistant)
+
+Do the CLI setup first (clone, build, config, `auth login`); the MCP server reads the
+same `~/.liads` credentials. Then register the server with your client:
+
+**Claude Code**
+
+```bash
+claude mcp add liam -- node /abs/path/liam/packages/mcp/dist/index.js
+```
+
+**Claude Desktop, Cursor, or any MCP client**, in its MCP config JSON:
 
 ```json
 {
   "mcpServers": {
-    "liam": { "command": "node", "args": ["/abs/path/linkedin-ads/packages/mcp/dist/index.js"] }
+    "liam": { "command": "node", "args": ["/abs/path/liam/packages/mcp/dist/index.js"] }
   }
 }
 ```
 
-## Option B — Host the MCP on Vercel (single-tenant, for you)
+Ask for something read-only to confirm it works: "List my ad accounts" or "How did my
+account do in the last 30 days?"
+
+**Hosted on Vercel (optional, single-tenant).** Run the MCP server in the cloud so it
+works from clients that can't spawn local processes:
 
 1. Get your env values locally: `node packages/cli/dist/index.js auth export`.
 2. Deploy `apps/web` to Vercel (set the project **Root Directory** to `apps/web`).
 3. In Vercel project settings, add the env vars from `.env.example`
    (`LIADS_CLIENT_ID`, `LIADS_CLIENT_SECRET`, `LIADS_REFRESH_TOKEN`, `LIADS_LINKEDIN_VERSION`,
    and a strong `MCP_AUTH_TOKEN`).
-4. Your MCP endpoint is `https://<your-app>.vercel.app/api/mcp`.
-
-Connect Claude to the remote server (header carries the secret):
+4. Your MCP endpoint is `https://<your-app>.vercel.app/api/mcp`. Connect with the secret
+   in the header:
 
 ```bash
+claude mcp add --transport http liam https://<your-app>.vercel.app/api/mcp \
+  --header "Authorization: Bearer <MCP_AUTH_TOKEN>"
+# or, for clients without native HTTP transport:
 npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Bearer <MCP_AUTH_TOKEN>"
+```
+
+The scraper engine for competitor ads needs a local browser, so it stays local-only; the
+hosted server uses the official Ad Library API engine.
+
+### Or paste this prompt and let your assistant do the setup
+
+Copy the whole block into Claude (or any capable assistant with terminal access) and it
+will walk you through everything above, one step at a time:
+
+```text
+You are helping me set up Liam, an open-source LinkedIn Ad Manager from
+https://github.com/stan-default/liam. It runs locally as an MCP server and a CLI.
+Everything it creates on LinkedIn is a draft, so nothing spends money until I
+activate it myself in Campaign Manager.
+
+Walk me through the setup one step at a time. Run commands for me where you can,
+show me exactly what to click where you cannot, and wait for my confirmation
+before moving to the next step.
+
+1. Check that git, Node.js 20 or newer, and pnpm are installed. Help me install
+   whatever is missing.
+2. Clone https://github.com/stan-default/liam and run "pnpm install" then
+   "pnpm -r build" in the repo root.
+3. Help me create a LinkedIn developer app at
+   https://www.linkedin.com/developers/apps (it must be associated with my
+   company's LinkedIn Page):
+   a. On the Products tab, request access to the "Advertising API" product.
+      This is the only required product; approval can take a while.
+   b. Optional: also request "Audiences" if I want to upload CSV contact or
+      company lists as matched audiences.
+   c. Optional: also request "LinkedIn Ad Library" if I want competitor ad
+      metadata through the official API.
+   d. On the Auth tab, add http://localhost:53682/callback as an authorized
+      redirect URL, and show me where the Client ID and Client Secret live.
+4. Create ~/.liads/config.json containing my clientId, clientSecret, and
+   "linkedinVersion": "202605".
+5. Run "node packages/cli/dist/index.js auth login". My browser opens LinkedIn's
+   consent screen; after I approve, tokens are stored in ~/.liads/credentials.json.
+6. Verify with "node packages/cli/dist/index.js accounts list". If no accounts
+   show up, remind me to map my ad account in the Developer Portal under
+   Products > Advertising API > View Ad Accounts. Then set my account id as
+   "defaultAccountId" in ~/.liads/config.json.
+7. Register the MCP server with the assistant I use:
+   - Claude Code: claude mcp add liam -- node <abs repo path>/packages/mcp/dist/index.js
+   - Claude Desktop or another client: add {"command": "node", "args":
+     ["<abs repo path>/packages/mcp/dist/index.js"]} under mcpServers in its config.
+8. Confirm the tools load, then show me one read-only call working, for example
+   list_ad_accounts or a last_30_days performance summary.
+
+If any step fails, show me the exact error and fix it with me before moving on.
 ```
 
 ## Tools (MCP)

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -240,37 +240,6 @@ body::after {
   color: var(--muted);
 }
 
-/* loops */
-.loops {
-  border: 1px solid var(--amber-dim);
-  background: var(--panel);
-}
-.loop {
-  display: flex;
-  gap: 20px;
-  padding: 16px 22px;
-  border-bottom: 1px solid var(--amber-dim);
-  align-items: baseline;
-}
-.loop:last-child {
-  border-bottom: none;
-}
-.loop .when {
-  flex: 0 0 110px;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--amber);
-  white-space: nowrap;
-}
-.loop .task {
-  font-size: 13.5px;
-  line-height: 1.65;
-  color: var(--muted);
-}
-.loop .task.cron {
-  color: var(--ink);
-}
-
 /* get started columns */
 .cols {
   display: grid;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -136,22 +136,179 @@ body::after {
   color: var(--amber);
 }
 
-/* connect */
-.connect {
-  margin-top: 48px;
+/* hero links */
+.heroLinks {
+  margin-top: 40px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 32px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
 }
-.connect .label {
+.heroLinks a {
+  color: var(--amber);
+  text-decoration: none;
+  border-bottom: 1px solid var(--amber-dim);
+  padding-bottom: 2px;
+  transition: border-color 0.18s;
+}
+.heroLinks a:hover {
+  border-color: var(--amber);
+}
+
+/* sections */
+.section {
+  padding: clamp(56px, 9vh, 96px) 0 0;
+}
+.kicker {
   font-size: 11px;
   letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--faint);
   margin-bottom: 12px;
 }
+.section h2 {
+  font-family: var(--font-display), sans-serif;
+  font-weight: 400;
+  font-size: clamp(28px, 4.6vw, 44px);
+  line-height: 1.05;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 18px;
+}
+.section .sub {
+  max-width: 64ch;
+  font-size: 14.5px;
+  line-height: 1.75;
+  color: var(--muted);
+  margin-bottom: 28px;
+}
+.section .sub a,
+.section .fine a {
+  color: var(--amber);
+  text-decoration: none;
+  border-bottom: 1px solid var(--amber-dim);
+}
+.section .sub a:hover,
+.section .fine a:hover {
+  border-color: var(--amber);
+}
+.section .sub em {
+  font-style: normal;
+  color: var(--ink);
+}
+.section code {
+  font-family: inherit;
+  color: var(--ink);
+  background: var(--amber-dim);
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
+/* use-case grid */
+.grid {
+  margin-top: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1px;
+  background: var(--amber-dim);
+  border: 1px solid var(--amber-dim);
+}
+.card {
+  background: var(--panel);
+  padding: 20px 22px 22px;
+  transition: background 0.18s;
+}
+.card:hover {
+  background: #171613;
+}
+.card .q {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ink);
+}
+.card .q .prompt {
+  color: var(--amber);
+  user-select: none;
+}
+.card .note,
+.col .note {
+  margin-top: 10px;
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+/* loops */
+.loops {
+  border: 1px solid var(--amber-dim);
+  background: var(--panel);
+}
+.loop {
+  display: flex;
+  gap: 20px;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--amber-dim);
+  align-items: baseline;
+}
+.loop:last-child {
+  border-bottom: none;
+}
+.loop .when {
+  flex: 0 0 110px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--amber);
+  white-space: nowrap;
+}
+.loop .task {
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--muted);
+}
+.loop .task.cron {
+  color: var(--ink);
+}
+
+/* get started columns */
+.cols {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+  margin-top: 8px;
+}
+.col h3 {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin-bottom: 8px;
+}
+.col .note {
+  margin: 10px 0 12px;
+}
+.fine {
+  margin-top: 24px;
+  font-size: 12.5px;
+  line-height: 1.65;
+  color: var(--muted);
+}
+
+/* setup prompt */
+.promptbox {
+  max-height: 420px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .code {
   position: relative;
   background: #060605;
   border: 1px solid var(--amber-dim);
-  padding: 18px 56px 18px 18px;
+  padding: 18px 72px 18px 18px;
   font-size: 13.5px;
   line-height: 1.7;
   color: var(--ink);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,9 +17,9 @@ const mono = IBM_Plex_Mono({
 });
 
 export const metadata = {
-  title: "Liam · LinkedIn Ad Manager",
+  title: "Liam · LinkedIn Ads Manager",
   description:
-    "Liam creates LinkedIn ad campaigns by talking to Claude, or from a CLI. An MCP server and CLI for go-to-market teams. Everything ships as a draft.",
+    "The LinkedIn Ads Manager you talk to. Describe the campaign and Liam drafts the audience, ad groups, and ads, from Claude over MCP or a CLI. Nothing spends until you activate it.",
 };
 
 export const viewport = {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
     <div className="wrap">
       <header className="topbar reveal d1">
         <span>
-          <b>LIAM</b> · LINKEDIN AD MANAGER
+          <b>LIAM</b> · LINKEDIN ADS MANAGER
         </span>
         <span className="status">
           <span className="dot" aria-hidden />
@@ -98,9 +98,9 @@ export default function Home() {
           </h1>
 
           <p className="tagline reveal d2">
-            Your <em>LinkedIn ad manager</em>. Describe the campaign in plain language and Liam
-            drafts the <em>audience</em>, <em>ad groups</em>, and <em>ads</em> for you. Talk to it
-            from <em>Claude over MCP</em>, or drive it from a <em>CLI</em>.{" "}
+            The <em>LinkedIn Ads Manager</em> you talk to. Describe the campaign in plain language
+            and Liam drafts the <em>audience</em>, the <em>ad groups</em>, and the <em>ads</em>.
+            Works from <em>Claude over MCP</em> or a <em>CLI</em>.{" "}
             <span className="hot">Nothing spends until you activate it.</span>
           </p>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -54,27 +54,8 @@ const USE_CASES: Array<{ q: string; note: string }> = [
     note: "LinkedIn ignores edits to a live ad's post, so Liam recreates it as a fresh draft.",
   },
   {
-    q: "Did the new headline actually help?",
-    note: "Every change is journaled; lift compares performance before and after.",
-  },
-];
-
-const LOOPS: Array<{ when: string; task: string }> = [
-  {
-    when: "MON 09:00",
-    task: "Pull last week's performance summary, compare it to the week before, and flag anything that moved more than 20%.",
-  },
-  {
-    when: "FRI 16:00",
-    task: "Check what new ads our top three competitors shipped this week and summarize the angles.",
-  },
-  {
-    when: "EVERY 4H",
-    task: "Check the audience match status and tell me when it clears 300 members.",
-  },
-  {
-    when: "1ST OF MONTH",
-    task: "Build last month's report: spend, CTR, cost per conversion, and the three ads I should kill.",
+    q: "Build last month's report: spend, CTR, cost per conversion, and the three ads I should kill.",
+    note: "Pulls the month's numbers and names the underperformers in one pass.",
   },
 ];
 
@@ -125,27 +106,6 @@ export default function Home() {
                 <p className="note">{u.note}</p>
               </div>
             ))}
-          </div>
-        </section>
-
-        <section id="loops" className="section">
-          <p className="kicker">Loops</p>
-          <h2>Put it on a schedule.</h2>
-          <p className="sub">
-            Liam has no scheduler of its own, and it does not need one: the client you drive it
-            from does. Tell Claude to run a prompt on a schedule, or put the CLI in cron.
-          </p>
-          <div className="loops">
-            {LOOPS.map((l) => (
-              <div className="loop" key={l.when}>
-                <span className="when">{l.when}</span>
-                <span className="task">&quot;{l.task}&quot;</span>
-              </div>
-            ))}
-            <div className="loop">
-              <span className="when">CRON</span>
-              <span className="task cron">0 9 * * 1 liam report summary -p last_7_days</span>
-            </div>
           </div>
         </section>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -54,7 +54,7 @@ const USE_CASES: Array<{ q: string; note: string }> = [
     note: "LinkedIn ignores edits to a live ad's post, so Liam recreates it as a fresh draft.",
   },
   {
-    q: "Build last month's report: spend, CTR, cost per conversion, and the three ads I should kill.",
+    q: "Build last month's report: spend, CTR, cost per conversion.",
     note: "Pulls the month's numbers and names the underperformers in one pass.",
   },
 ];

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,82 @@
 import { CopyButton } from "./CopyButton";
+import { SETUP_PROMPT } from "./setupPrompt";
 
-const CONNECT_CMD =
-  'npx mcp-remote https://liam-mcp.vercel.app/api/mcp --header "Authorization: Bearer <MCP_AUTH_TOKEN>"';
+const REPO = "https://github.com/stan-default/liam";
+
+const CLI_CMD = `git clone ${REPO}.git liam
+cd liam
+pnpm install && pnpm -r build
+node packages/cli/dist/index.js auth login
+node packages/cli/dist/index.js accounts list`;
+
+const MCP_CMD = "claude mcp add liam -- node /abs/path/liam/packages/mcp/dist/index.js";
+
+const MCP_JSON = `{
+  "mcpServers": {
+    "liam": {
+      "command": "node",
+      "args": ["/abs/path/liam/packages/mcp/dist/index.js"]
+    }
+  }
+}`;
+
+const USE_CASES: Array<{ q: string; note: string }> = [
+  {
+    q: "How many VPs of demand gen at US SaaS companies can we reach?",
+    note: "Resolves targeting facets and estimates reach before any money is involved.",
+  },
+  {
+    q: "Upload this CSV as a matched audience.",
+    note: "Cleans the columns, hashes emails, converts company domains to URLs.",
+  },
+  {
+    q: "Build an audience from Salesforce: every contact on a target account.",
+    note: "A SOQL query becomes a matched audience, no export step.",
+  },
+  {
+    q: "Launch a draft campaign for that audience, $100 a day.",
+    note: "Campaign group, ad group, and draft ads in one call, conversion attached.",
+  },
+  {
+    q: "What ads is HubSpot running, and what offers are they pushing?",
+    note: "Reads any company's ads from the public Ad Library: copy, formats, EU targeting.",
+  },
+  {
+    q: "How did retargeting do last month vs the month before?",
+    note: "Trend reports with deltas at any level: account, campaign, single ad.",
+  },
+  {
+    q: "Which ads should I pause this week?",
+    note: "Account rollup with top and bottom performers, plus flags worth acting on.",
+  },
+  {
+    q: "Rewrite the copy on the losing ad.",
+    note: "LinkedIn ignores edits to a live ad's post, so Liam recreates it as a fresh draft.",
+  },
+  {
+    q: "Did the new headline actually help?",
+    note: "Every change is journaled; lift compares performance before and after.",
+  },
+];
+
+const LOOPS: Array<{ when: string; task: string }> = [
+  {
+    when: "MON 09:00",
+    task: "Pull last week's performance summary, compare it to the week before, and flag anything that moved more than 20%.",
+  },
+  {
+    when: "FRI 16:00",
+    task: "Check what new ads our top three competitors shipped this week and summarize the angles.",
+  },
+  {
+    when: "EVERY 4H",
+    task: "Check the audience match status and tell me when it clears 300 members.",
+  },
+  {
+    when: "1ST OF MONTH",
+    task: "Build last month's report: spend, CTR, cost per conversion, and the three ads I should kill.",
+  },
+];
 
 export default function Home() {
   return (
@@ -16,31 +91,138 @@ export default function Home() {
         </span>
       </header>
 
-      <main className="hero">
-        <h1 className="wordmark reveal d1">
-          LIAM<span className="caret" aria-hidden />
-        </h1>
+      <main>
+        <section className="hero">
+          <h1 className="wordmark reveal d1">
+            LIAM<span className="caret" aria-hidden />
+          </h1>
 
-        <p className="tagline reveal d2">
-          Your <em>LinkedIn ad manager</em>. Describe the campaign in plain language and Liam
-          drafts the <em>audience</em>, <em>ad groups</em>, and <em>ads</em> for you. Built from a
-          contact list and a brief, served over <em>MCP</em> or a CLI.{" "}
-          <span className="hot">Nothing spends until you activate it.</span>
-        </p>
+          <p className="tagline reveal d2">
+            Your <em>LinkedIn ad manager</em>. Describe the campaign in plain language and Liam
+            drafts the <em>audience</em>, <em>ad groups</em>, and <em>ads</em> for you. Talk to it
+            from <em>Claude over MCP</em>, or drive it from a <em>CLI</em>.{" "}
+            <span className="hot">Nothing spends until you activate it.</span>
+          </p>
 
-        <section className="connect reveal d3">
-          <p className="label">Connect a client</p>
-          <pre className="code">
-            <CopyButton text={CONNECT_CMD} />
-            <span className="prompt">$ </span>npx mcp-remote https://liam-mcp.vercel.app/api/mcp{"\n"}
-            {"  "}<span className="flag">--header</span> &quot;Authorization: Bearer &lt;MCP_AUTH_TOKEN&gt;&quot;
+          <p className="heroLinks reveal d3">
+            <a href="#get-started">Get started ↓</a>
+            <a href="#use-cases">What it can do ↓</a>
+            <a href={REPO} target="_blank" rel="noreferrer">
+              GitHub ↗
+            </a>
+          </p>
+        </section>
+
+        <section id="use-cases" className="section">
+          <p className="kicker">What you can do</p>
+          <h2>Ask it like you would ask a teammate.</h2>
+          <div className="grid">
+            {USE_CASES.map((u) => (
+              <div className="card" key={u.q}>
+                <p className="q">
+                  <span className="prompt">&gt; </span>
+                  {u.q}
+                </p>
+                <p className="note">{u.note}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="loops" className="section">
+          <p className="kicker">Loops</p>
+          <h2>Put it on a schedule.</h2>
+          <p className="sub">
+            Liam has no scheduler of its own, and it does not need one: the client you drive it
+            from does. Tell Claude to run a prompt on a schedule, or put the CLI in cron.
+          </p>
+          <div className="loops">
+            {LOOPS.map((l) => (
+              <div className="loop" key={l.when}>
+                <span className="when">{l.when}</span>
+                <span className="task">&quot;{l.task}&quot;</span>
+              </div>
+            ))}
+            <div className="loop">
+              <span className="when">CRON</span>
+              <span className="task cron">0 9 * * 1 liam report summary -p last_7_days</span>
+            </div>
+          </div>
+        </section>
+
+        <section id="get-started" className="section">
+          <p className="kicker">Get started</p>
+          <h2>Bring your own LinkedIn app.</h2>
+          <p className="sub">
+            Liam runs against your own LinkedIn developer app, so your credentials and your ad
+            account stay yours. Create an app at{" "}
+            <a href="https://www.linkedin.com/developers/apps" target="_blank" rel="noreferrer">
+              linkedin.com/developers/apps
+            </a>
+            , request the <em>Advertising API</em> product (add <em>Audiences</em> for CSV uploads
+            and <em>Ad Library</em> for competitor metadata), and add{" "}
+            <code>http://localhost:53682/callback</code> as a redirect URL. Login asks for the{" "}
+            <code>rw_ads</code>, <code>r_ads_reporting</code>, <code>rw_conversions</code>, and{" "}
+            <code>w_organization_social</code> scopes.
+          </p>
+
+          <div className="cols">
+            <div className="col">
+              <h3>1 · The CLI</h3>
+              <p className="note">
+                Clone, build, log in through your browser, and verify. Then every capability is a{" "}
+                <code>liam</code> command.
+              </p>
+              <pre className="code">
+                <CopyButton text={CLI_CMD} />
+                {CLI_CMD}
+              </pre>
+            </div>
+            <div className="col">
+              <h3>2 · MCP</h3>
+              <p className="note">
+                Same setup, then register the server so Claude can use it. One line in Claude
+                Code:
+              </p>
+              <pre className="code">
+                <CopyButton text={MCP_CMD} />
+                {MCP_CMD}
+              </pre>
+              <p className="note">Claude Desktop, Cursor, or any MCP client:</p>
+              <pre className="code">
+                <CopyButton text={MCP_JSON} />
+                {MCP_JSON}
+              </pre>
+            </div>
+          </div>
+
+          <p className="note fine">
+            Want it in the cloud? The repo ships a single-tenant hosted mode for Vercel. See the{" "}
+            <a href={`${REPO}#get-started`} target="_blank" rel="noreferrer">
+              README
+            </a>{" "}
+            for the full walkthrough, permissions table, and hosted setup.
+          </p>
+        </section>
+
+        <section id="setup-prompt" className="section">
+          <p className="kicker">One prompt setup</p>
+          <h2>Or paste this into Claude.</h2>
+          <p className="sub">
+            Copy the whole block into Claude (or any assistant with terminal access) and it walks
+            you through everything: prerequisites, the LinkedIn app, login, and connecting the
+            MCP server.
+          </p>
+          <pre className="code promptbox" tabIndex={0}>
+            <CopyButton text={SETUP_PROMPT} />
+            {SETUP_PROMPT}
           </pre>
         </section>
       </main>
 
-      <footer className="footer reveal d4">
+      <footer className="footer">
         <span>Unofficial. Not affiliated with or endorsed by LinkedIn.</span>
-        <a href="https://github.com/stan-default/liam" target="_blank" rel="noreferrer">
+        <a href={REPO} target="_blank" rel="noreferrer">
           github.com/stan-default/liam ↗
         </a>
       </footer>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -100,8 +100,7 @@ export default function Home() {
           <p className="tagline reveal d2">
             The <em>LinkedIn Ads Manager</em> you talk to. Describe the campaign in plain language
             and Liam drafts the <em>audience</em>, the <em>ad groups</em>, and the <em>ads</em>.
-            Works from <em>Claude over MCP</em> or a <em>CLI</em>.{" "}
-            <span className="hot">Nothing spends until you activate it.</span>
+            Works from <em>Claude over MCP</em> or a <em>CLI</em>.
           </p>
 
           <p className="heroLinks reveal d3">

--- a/apps/web/app/setupPrompt.ts
+++ b/apps/web/app/setupPrompt.ts
@@ -1,0 +1,44 @@
+/**
+ * The paste-in setup prompt shown on the landing page. Keep in sync with the
+ * copy in README.md ("Or paste this prompt and let your assistant do the setup").
+ */
+export const SETUP_PROMPT = `You are helping me set up Liam, an open-source LinkedIn Ad Manager from
+https://github.com/stan-default/liam. It runs locally as an MCP server and a CLI.
+Everything it creates on LinkedIn is a draft, so nothing spends money until I
+activate it myself in Campaign Manager.
+
+Walk me through the setup one step at a time. Run commands for me where you can,
+show me exactly what to click where you cannot, and wait for my confirmation
+before moving to the next step.
+
+1. Check that git, Node.js 20 or newer, and pnpm are installed. Help me install
+   whatever is missing.
+2. Clone https://github.com/stan-default/liam and run "pnpm install" then
+   "pnpm -r build" in the repo root.
+3. Help me create a LinkedIn developer app at
+   https://www.linkedin.com/developers/apps (it must be associated with my
+   company's LinkedIn Page):
+   a. On the Products tab, request access to the "Advertising API" product.
+      This is the only required product; approval can take a while.
+   b. Optional: also request "Audiences" if I want to upload CSV contact or
+      company lists as matched audiences.
+   c. Optional: also request "LinkedIn Ad Library" if I want competitor ad
+      metadata through the official API.
+   d. On the Auth tab, add http://localhost:53682/callback as an authorized
+      redirect URL, and show me where the Client ID and Client Secret live.
+4. Create ~/.liads/config.json containing my clientId, clientSecret, and
+   "linkedinVersion": "202605".
+5. Run "node packages/cli/dist/index.js auth login". My browser opens LinkedIn's
+   consent screen; after I approve, tokens are stored in ~/.liads/credentials.json.
+6. Verify with "node packages/cli/dist/index.js accounts list". If no accounts
+   show up, remind me to map my ad account in the Developer Portal under
+   Products > Advertising API > View Ad Accounts. Then set my account id as
+   "defaultAccountId" in ~/.liads/config.json.
+7. Register the MCP server with the assistant I use:
+   - Claude Code: claude mcp add liam -- node <abs repo path>/packages/mcp/dist/index.js
+   - Claude Desktop or another client: add {"command": "node", "args":
+     ["<abs repo path>/packages/mcp/dist/index.js"]} under mcpServers in its config.
+8. Confirm the tools load, then show me one read-only call working, for example
+   list_ad_accounts or a last_30_days performance summary.
+
+If any step fails, show me the exact error and fix it with me before moving on.`;

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -15,8 +15,13 @@ import type { TokenProvider } from "./http.js";
 const AUTH_URL = "https://www.linkedin.com/oauth/v2/authorization";
 const TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken";
 
-/** Scopes for ad management. r_ads_reporting is for Phase 2 analytics. rw_conversions is for the Conversions API. */
-export const DEFAULT_SCOPES = ["rw_ads", "r_ads_reporting", "rw_conversions"];
+/**
+ * Scopes for ad management. r_ads_reporting is reporting, rw_conversions is the
+ * Conversions API, and w_organization_social lets image ads create the Direct
+ * Sponsored Content post owned by your LinkedIn Page. Adding a scope later
+ * requires a fresh `auth login`: refreshing a token keeps only the old scopes.
+ */
+export const DEFAULT_SCOPES = ["rw_ads", "r_ads_reporting", "rw_conversions", "w_organization_social"];
 
 const CALLBACK_PORT = 53682;
 


### PR DESCRIPTION
## What this does

Makes Liam usable by someone who is not Stan. Two clear paths, documented on the GitHub README and on the landing page.

### README
- New **Get started** replaces the old Prerequisites / Option A / Option B sections:
  - **Step 0: create a LinkedIn app.** Products table (Advertising API required, Audiences and Ad Library optional), redirect URL, ad-account mapping tip, and the four OAuth scopes explained, including the note that adding a scope later needs a fresh `auth login` because token refresh keeps only the old grants.
  - **Path 1: the CLI.** Clone, build, config, browser login, verify, plus a global `liam` command via `pnpm link --global` and a suggested first session.
  - **Path 2: MCP.** Claude Code one-liner (`claude mcp add`), config JSON for Claude Desktop / Cursor / any client, and the optional single-tenant Vercel hosted mode with both `--transport http` and `mcp-remote` connect commands.
  - **A paste-in setup prompt.** Copy one block into Claude and it drives the whole setup: prerequisites, the LinkedIn app, login, verification, and MCP registration.
- The intro examples grew into a **"What you can do with it"** list (nine real requests, from reach estimates to lift analysis) plus **"Put it on a loop"**: scheduled-agent prompts like a Monday-morning performance summary, and a plain cron line for the CLI.

### Landing page
- **Use-cases grid**: the same nine requests, phrased as prompts with a one-line note on what Liam does under the hood.
- **Loops section**: schedule-style rows (Monday summary, Friday competitor scan, audience-match watch, monthly report) plus the cron one-liner.
- **Get started**: LinkedIn app requirements and scopes, then CLI and MCP side by side with copy buttons.
- **One-prompt setup**: the same paste-in prompt with a copy button (shared constant in `setupPrompt.ts`, kept in sync with the README).
- Hero now links down the page instead of showing the single-tenant hosted connect command, which would not work for anyone else anyway.

### Code
- `DEFAULT_SCOPES` now includes `w_organization_social`, so image ads (which create a Page-owned Direct Sponsored Content post) work for new users without a manual re-auth.

## Verified
- `pnpm -r build` passes (core, mcp, cli, web).
- Screenshotted the built site at desktop and 390px mobile widths; sections match the existing amber terminal style and the code blocks scroll instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)