### PR TITLE
One-prompt setup and an FAQ on the landing page

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -112,15 +112,6 @@ body::after {
   display: flex;
   align-items: flex-end;
 }
-.caret {
-  display: inline-block;
-  width: clamp(20px, 5vw, 56px);
-  height: clamp(64px, 17vw, 200px);
-  background: var(--amber);
-  margin-left: clamp(10px, 2vw, 22px);
-  margin-bottom: clamp(8px, 2vw, 24px);
-  animation: blink 1.1s steps(1) infinite;
-}
 .tagline {
   margin-top: 30px;
   max-width: 60ch;
@@ -402,16 +393,11 @@ body::after {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.35; }
 }
-@keyframes blink {
-  0%, 50% { opacity: 1; }
-  50.01%, 100% { opacity: 0; }
-}
-
 @media (max-width: 560px) {
   .topbar { font-size: 10px; letter-spacing: 0.12em; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .reveal { animation: none; opacity: 1; transform: none; }
-  .dot, .caret { animation: none; }
+  .dot { animation: none; }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -266,11 +266,78 @@ body::after {
 }
 
 /* setup prompt */
-.promptbox {
+.code.promptbox {
   max-height: 420px;
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-word;
+}
+.cols .code.promptbox {
+  max-height: 320px;
+}
+.prompthead {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 8px 76px 8px 14px;
+  background: #0e0e0c;
+  border: 1px solid var(--amber-dim);
+  border-bottom: none;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.promptcard .code {
+  padding-right: 18px;
+}
+
+/* faq */
+.faq {
+  border: 1px solid var(--amber-dim);
+  background: var(--panel);
+}
+.faq details {
+  border-bottom: 1px solid var(--amber-dim);
+}
+.faq details:last-child {
+  border-bottom: none;
+}
+.faq summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 18px 22px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  transition: background 0.18s;
+}
+.faq summary::-webkit-details-marker {
+  display: none;
+}
+.faq summary::after {
+  content: "+";
+  color: var(--amber);
+  flex: none;
+  font-weight: 400;
+}
+.faq details[open] summary::after {
+  content: "\2212";
+}
+.faq summary:hover {
+  background: #171613;
+}
+.faq .a {
+  padding: 2px 22px 20px;
+  max-width: 72ch;
+  font-size: 13.5px;
+  line-height: 1.75;
+  color: var(--muted);
 }
 
 .code {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,24 +1,46 @@
 import { CopyButton } from "./CopyButton";
-import { SETUP_PROMPT } from "./setupPrompt";
+import { CLI_SETUP_PROMPT, MCP_SETUP_PROMPT } from "./setupPrompt";
 
 const REPO = "https://github.com/stan-default/liam";
 
-const CLI_CMD = `git clone ${REPO}.git liam
-cd liam
-pnpm install && pnpm -r build
-node packages/cli/dist/index.js auth login
-node packages/cli/dist/index.js accounts list`;
-
-const MCP_CMD = "claude mcp add liam -- node /abs/path/liam/packages/mcp/dist/index.js";
-
-const MCP_JSON = `{
-  "mcpServers": {
-    "liam": {
-      "command": "node",
-      "args": ["/abs/path/liam/packages/mcp/dist/index.js"]
-    }
-  }
-}`;
+const FAQ: Array<{ q: string; a: string }> = [
+  {
+    q: "Can it spend money without me?",
+    a: "No. Everything Liam creates is written to LinkedIn as a draft, and there is deliberately no activate command or tool anywhere in the codebase. A campaign starts spending only when you switch it on yourself in Campaign Manager.",
+  },
+  {
+    q: "What permissions does it need?",
+    a: "Liam runs against your own LinkedIn developer app with the Advertising API product. At login it asks for four OAuth scopes: rw_ads to create and edit campaigns, r_ads_reporting to read performance, rw_conversions for conversion tracking, and w_organization_social so image ads can create the post owned by your LinkedIn Page. Two optional products unlock more: Audiences for CSV list uploads and Ad Library for competitor metadata.",
+  },
+  {
+    q: "How does it work?",
+    a: "A CLI and an MCP server sit on top of the same typed client for LinkedIn's Marketing API. You say what you want, your assistant calls the matching tools, and LinkedIn returns the ids. Every change Liam makes is journaled to a local file so you can measure the lift of any edit later.",
+  },
+  {
+    q: "How do I get started?",
+    a: "Copy one of the prompts above into Claude Code. It installs the prerequisites, walks you through creating the LinkedIn app, logs you in through your browser, and verifies everything with a read-only call. The hands-on part takes about 15 minutes; LinkedIn's approval of the Advertising API product can add a day or two of waiting.",
+  },
+  {
+    q: "Do I need to be a developer?",
+    a: "You need a terminal with Claude Code installed, and the setup prompt does the rest. If you can paste a block of text and click approve in your browser, you can finish the setup.",
+  },
+  {
+    q: "Where do my credentials live?",
+    a: "In a ~/.liads folder on your own machine, with file permissions locked to your user. Tokens go to LinkedIn's API and nowhere else. If you deploy the optional hosted mode, the credentials live in your own Vercel project's environment variables.",
+  },
+  {
+    q: "What does it cost?",
+    a: "Nothing. Liam is open source under the MIT license, and there is no hosted service to subscribe to. The only money involved is what you choose to spend on LinkedIn after you activate a campaign.",
+  },
+  {
+    q: "Does it only work with Claude?",
+    a: "It works with any MCP client: Claude Code, Claude Desktop, Cursor, and the rest. The CLI needs no assistant at all, so you can script it, pipe it, or put a weekly report in cron.",
+  },
+  {
+    q: "Is this an official LinkedIn product?",
+    a: "No. Liam is unofficial and has no affiliation with or endorsement from LinkedIn. It talks to LinkedIn's documented Marketing API through the developer app you create and control.",
+  },
+];
 
 const USE_CASES: Array<{ q: string; note: string }> = [
   {
@@ -87,6 +109,7 @@ export default function Home() {
           <p className="heroLinks reveal d3">
             <a href="#get-started">Get started ↓</a>
             <a href="#use-cases">What it can do ↓</a>
+            <a href="#faq">FAQ ↓</a>
             <a href={REPO} target="_blank" rel="noreferrer">
               GitHub ↗
             </a>
@@ -111,71 +134,68 @@ export default function Home() {
 
         <section id="get-started" className="section">
           <p className="kicker">Get started</p>
-          <h2>Bring your own LinkedIn app.</h2>
+          <h2>One prompt sets everything up.</h2>
           <p className="sub">
-            Liam runs against your own LinkedIn developer app, so your credentials and your ad
-            account stay yours. Create an app at{" "}
-            <a href="https://www.linkedin.com/developers/apps" target="_blank" rel="noreferrer">
-              linkedin.com/developers/apps
-            </a>
-            , request the <em>Advertising API</em> product (add <em>Audiences</em> for CSV uploads
-            and <em>Ad Library</em> for competitor metadata), and add{" "}
-            <code>http://localhost:53682/callback</code> as a redirect URL. Login asks for the{" "}
-            <code>rw_ads</code>, <code>r_ads_reporting</code>, <code>rw_conversions</code>, and{" "}
-            <code>w_organization_social</code> scopes.
+            Pick how you want to use Liam, copy the prompt, and paste it into Claude Code. It
+            checks your machine, helps you create your own LinkedIn developer app, logs you in,
+            and verifies the connection, one step at a time.
           </p>
 
           <div className="cols">
             <div className="col">
-              <h3>1 · The CLI</h3>
+              <h3>Use it as a CLI</h3>
               <p className="note">
-                Clone, build, log in through your browser, and verify. Then every capability is a{" "}
-                <code>liam</code> command.
+                For scripted and batch work in the terminal. Ends with a global <code>liam</code>{" "}
+                command and your first report.
               </p>
-              <pre className="code">
-                <CopyButton text={CLI_CMD} />
-                {CLI_CMD}
-              </pre>
+              <div className="promptcard">
+                <div className="prompthead">
+                  <span>setup prompt · paste into claude code</span>
+                  <CopyButton text={CLI_SETUP_PROMPT} />
+                </div>
+                <pre className="code promptbox" tabIndex={0}>
+                  {CLI_SETUP_PROMPT}
+                </pre>
+              </div>
             </div>
             <div className="col">
-              <h3>2 · MCP</h3>
+              <h3>Talk to it over MCP</h3>
               <p className="note">
-                Same setup, then register the server so Claude can use it. One line in Claude
-                Code:
+                For plain-language campaign work in Claude. Ends with the server registered in
+                Claude Code, plus the config for Claude Desktop or any MCP client.
               </p>
-              <pre className="code">
-                <CopyButton text={MCP_CMD} />
-                {MCP_CMD}
-              </pre>
-              <p className="note">Claude Desktop, Cursor, or any MCP client:</p>
-              <pre className="code">
-                <CopyButton text={MCP_JSON} />
-                {MCP_JSON}
-              </pre>
+              <div className="promptcard">
+                <div className="prompthead">
+                  <span>setup prompt · paste into claude code</span>
+                  <CopyButton text={MCP_SETUP_PROMPT} />
+                </div>
+                <pre className="code promptbox" tabIndex={0}>
+                  {MCP_SETUP_PROMPT}
+                </pre>
+              </div>
             </div>
           </div>
 
           <p className="note fine">
-            Want it in the cloud? The repo ships a single-tenant hosted mode for Vercel. See the{" "}
+            Prefer to do it by hand, or want the single-tenant hosted mode on Vercel? The{" "}
             <a href={`${REPO}#get-started`} target="_blank" rel="noreferrer">
               README
             </a>{" "}
-            for the full walkthrough, permissions table, and hosted setup.
+            has the full manual walkthrough and the permissions table.
           </p>
         </section>
 
-        <section id="setup-prompt" className="section">
-          <p className="kicker">One prompt setup</p>
-          <h2>Or paste this into Claude.</h2>
-          <p className="sub">
-            Copy the whole block into Claude (or any assistant with terminal access) and it walks
-            you through everything: prerequisites, the LinkedIn app, login, and connecting the
-            MCP server.
-          </p>
-          <pre className="code promptbox" tabIndex={0}>
-            <CopyButton text={SETUP_PROMPT} />
-            {SETUP_PROMPT}
-          </pre>
+        <section id="faq" className="section">
+          <p className="kicker">FAQ</p>
+          <h2>The questions worth asking first.</h2>
+          <div className="faq">
+            {FAQ.map((f) => (
+              <details key={f.q}>
+                <summary>{f.q}</summary>
+                <p className="a">{f.a}</p>
+              </details>
+            ))}
+          </div>
         </section>
       </main>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -96,9 +96,7 @@ export default function Home() {
 
       <main>
         <section className="hero">
-          <h1 className="wordmark reveal d1">
-            LIAM<span className="caret" aria-hidden />
-          </h1>
+          <h1 className="wordmark reveal d1">LIAM</h1>
 
           <p className="tagline reveal d2">
             The <em>LinkedIn Ads Manager</em> you talk to. Describe the campaign in plain language
@@ -161,8 +159,8 @@ export default function Home() {
             <div className="col">
               <h3>Talk to it over MCP</h3>
               <p className="note">
-                For plain-language campaign work in Claude. Ends with the server registered in
-                Claude Code, plus the config for Claude Desktop or any MCP client.
+                Adds Liam as an MCP server in Claude Code, Claude Desktop, or any MCP client.
+                The one-time install runs only if it is not on your machine yet.
               </p>
               <div className="promptcard">
                 <div className="prompthead">

--- a/apps/web/app/setupPrompt.ts
+++ b/apps/web/app/setupPrompt.ts
@@ -1,9 +1,10 @@
 /**
- * The paste-in setup prompt shown on the landing page. Keep in sync with the
- * copy in README.md ("Or paste this prompt and let your assistant do the setup").
+ * The paste-in setup prompts shown on the landing page. Both share the same
+ * core steps; only the last mile differs (CLI usage vs registering the MCP
+ * server). README.md carries a combined version of the same walkthrough.
  */
-export const SETUP_PROMPT = `You are helping me set up Liam, an open-source LinkedIn Ad Manager from
-https://github.com/stan-default/liam. It runs locally as an MCP server and a CLI.
+const INTRO = `You are helping me set up Liam, an open-source LinkedIn Ads Manager from
+https://github.com/stan-default/liam. It runs locally as a CLI and an MCP server.
 Everything it creates on LinkedIn is a draft, so nothing spends money until I
 activate it myself in Campaign Manager.
 
@@ -33,12 +34,24 @@ before moving to the next step.
 6. Verify with "node packages/cli/dist/index.js accounts list". If no accounts
    show up, remind me to map my ad account in the Developer Portal under
    Products > Advertising API > View Ad Accounts. Then set my account id as
-   "defaultAccountId" in ~/.liads/config.json.
-7. Register the MCP server with the assistant I use:
-   - Claude Code: claude mcp add liam -- node <abs repo path>/packages/mcp/dist/index.js
-   - Claude Desktop or another client: add {"command": "node", "args":
-     ["<abs repo path>/packages/mcp/dist/index.js"]} under mcpServers in its config.
-8. Confirm the tools load, then show me one read-only call working, for example
-   list_ad_accounts or a last_30_days performance summary.
+   "defaultAccountId" in ~/.liads/config.json.`;
+
+const OUTRO = `
 
 If any step fails, show me the exact error and fix it with me before moving on.`;
+
+export const CLI_SETUP_PROMPT = `${INTRO}
+7. Link the CLI globally with "cd packages/cli && pnpm link --global" so I can
+   run "liam" from anywhere, and confirm "liam accounts list" works.
+8. Show me a first session: "liam report summary -p last_30_days" and
+   "liam targeting search titles" with a title I care about.${OUTRO}`;
+
+export const MCP_SETUP_PROMPT = `${INTRO}
+7. Register the MCP server:
+   - In Claude Code: claude mcp add liam -- node <abs repo path>/packages/mcp/dist/index.js
+   - For Claude Desktop or another MCP client, print the JSON I need to add
+     under mcpServers in its config ({"command": "node", "args":
+     ["<abs repo path>/packages/mcp/dist/index.js"]}) and tell me where that
+     config file lives on my machine.
+8. Confirm the tools load, then show me one read-only call working, for example
+   list_ad_accounts or a last_30_days performance summary.${OUTRO}`;

--- a/apps/web/app/setupPrompt.ts
+++ b/apps/web/app/setupPrompt.ts
@@ -46,12 +46,27 @@ export const CLI_SETUP_PROMPT = `${INTRO}
 8. Show me a first session: "liam report summary -p last_30_days" and
    "liam targeting search titles" with a title I care about.${OUTRO}`;
 
-export const MCP_SETUP_PROMPT = `${INTRO}
-7. Register the MCP server:
+export const MCP_SETUP_PROMPT = `You are helping me connect Liam, an open-source LinkedIn Ads Manager
+(https://github.com/stan-default/liam), to Claude as an MCP server. Everything
+it creates on LinkedIn is a draft, so nothing spends money until I activate it
+myself in Campaign Manager.
+
+Work one step at a time, run commands for me where you can, and wait for my
+confirmation before moving on.
+
+1. Register the MCP server:
    - In Claude Code: claude mcp add liam -- node <abs repo path>/packages/mcp/dist/index.js
-   - For Claude Desktop or another MCP client, print the JSON I need to add
-     under mcpServers in its config ({"command": "node", "args":
-     ["<abs repo path>/packages/mcp/dist/index.js"]}) and tell me where that
-     config file lives on my machine.
-8. Confirm the tools load, then show me one read-only call working, for example
-   list_ad_accounts or a last_30_days performance summary.${OUTRO}`;
+   - For Claude Desktop or another MCP client, add {"command": "node", "args":
+     ["<abs repo path>/packages/mcp/dist/index.js"]} under mcpServers in its
+     config, and tell me where that config file lives on my machine.
+2. Confirm the liam tools load, then show me one read-only call working, for
+   example list_ad_accounts or a last_30_days performance summary.
+
+Only if step 1 has nothing to point at yet, do the one-time install first:
+clone https://github.com/stan-default/liam, run "pnpm install" and
+"pnpm -r build", put the clientId and clientSecret from my LinkedIn developer
+app (Advertising API product, redirect URL http://localhost:53682/callback)
+in ~/.liads/config.json, then run "node packages/cli/dist/index.js auth login"
+and verify with "node packages/cli/dist/index.js accounts list".
+
+If a step fails, show me the exact error and fix it with me before moving on.`;


### PR DESCRIPTION
## What this does

Makes the setup genuinely one-click and answers the questions a head of growth asks before trying it.

### One-prompt setup
- "Get started" is now: pick your surface, copy one prompt, paste it into Claude Code.
  - **Use it as a CLI**: the prompt ends by linking a global `liam` command and running a first report.
  - **Talk to it over MCP**: the prompt ends by registering the server in Claude Code and printing the config for Claude Desktop or any other MCP client.
- Both prompts share the same core steps (prerequisites, clone and build, LinkedIn app with products and redirect URL, config, browser login, account verification) via a single source in `setupPrompt.ts`, so they cannot drift.
- Prompt cards got a header bar with the copy button, fixing the button overlapping the first line of text. Prompt text now wraps inside the box instead of clipping.
- The manual command blocks and the separate setup-prompt section are gone; the README still carries the full manual walkthrough and is linked for people who prefer it or want the hosted Vercel mode.

### FAQ
New section with native accordions, no JavaScript, answering: can it spend money without me, what permissions it needs (products and the four OAuth scopes), how it works, how to get started and how long it takes, whether you need a developer, where credentials live, what it costs, whether it only works with Claude, and whether it is official.

## Verified
- `next build` passes.
- Screenshotted the served page: prompt cards wrap and scroll correctly, copy header sits above the text, FAQ opens and closes with the amber plus/minus indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)