### PR TITLE
README: two explicit install paths (MCP server and terminal CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,20 @@ local change journal (`~/.liads/changelog.jsonl`) for later lift analysis.
 [AGENTS.md](./AGENTS.md) has the full architecture notes and the LinkedIn API gotchas
 (restli encoding, required fields, DMP audience flow) learned from live testing.
 
-## Get started
+## Install
 
-There are two ways to use Liam: as a CLI in your terminal, or as an MCP server your
-assistant talks to. Both run against **your own LinkedIn developer app**, so your
-credentials and your ad account stay yours. Both start with the same step 0.
+There are two ways to install Liam:
+
+1. **[As an MCP server](#option-1-install-as-an-mcp-server)**, registered with Claude
+   Code, Claude Desktop, Cursor, or any MCP client, so you create campaigns by talking
+   to your assistant.
+2. **[As a terminal CLI](#option-2-install-the-terminal-cli)**, a global `liam` command
+   for running everything from your terminal, scripts, or cron.
+
+Both run against **your own LinkedIn developer app**, so your credentials and your ad
+account stay yours. Both share the same first two steps: create a LinkedIn app (step 0)
+and build + authenticate (step 1). After that, pick your path, or do both; they read the
+same `~/.liads` credentials.
 
 ### Step 0: create a LinkedIn app (once)
 
@@ -116,7 +125,9 @@ credentials and your ad account stay yours. Both start with the same step 0.
 a product or scope later, run `auth login` again; a token refresh keeps only the scopes
 you originally granted.
 
-### Path 1: the CLI
+### Step 1: build and authenticate (once, both paths)
+
+Requires git, Node.js 20+, and pnpm.
 
 ```bash
 git clone https://github.com/stan-default/liam.git
@@ -131,29 +142,9 @@ node packages/cli/dist/index.js auth login      # opens the browser; tokens land
 node packages/cli/dist/index.js accounts list   # verify, then set defaultAccountId in config.json
 ```
 
-To get a global `liam` command instead of the long `node` path:
+### Option 1: install as an MCP server
 
-```bash
-cd packages/cli && pnpm link --global
-liam accounts list
-```
-
-(No pnpm? An alias works too: `alias liam="node /abs/path/liam/packages/cli/dist/index.js"`.)
-
-A sensible first session:
-
-```bash
-liam targeting search titles "demand generation"   # resolve targeting URNs
-liam report summary -p last_30_days                # account rollup + flags
-liam launch --brief examples/brief.json            # creates DRAFTS only
-```
-
-The full [CLI reference](#cli-reference) is below.
-
-### Path 2: MCP (talk to it from your assistant)
-
-Do the CLI setup first (clone, build, config, `auth login`); the MCP server reads the
-same `~/.liads` credentials. Then register the server with your client:
+Register the server with your MCP client; it reads the `~/.liads` credentials from step 1.
 
 **Claude Code**
 
@@ -194,6 +185,28 @@ npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Be
 
 The scraper engine for competitor ads needs a local browser, so it stays local-only; the
 hosted server uses the official Ad Library API engine.
+
+### Option 2: install the terminal CLI
+
+Step 1 already left a working CLI at `node packages/cli/dist/index.js`. To get a global
+`liam` command instead of the long `node` path:
+
+```bash
+cd packages/cli && pnpm link --global
+liam accounts list
+```
+
+(No pnpm link? An alias works too: `alias liam="node /abs/path/liam/packages/cli/dist/index.js"`.)
+
+A sensible first session:
+
+```bash
+liam targeting search titles "demand generation"   # resolve targeting URNs
+liam report summary -p last_30_days                # account rollup + flags
+liam launch --brief examples/brief.json            # creates DRAFTS only
+```
+
+The full [CLI reference](#cli-reference) is below.
 
 ### Or paste this prompt and let your assistant do the setup
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -176,7 +176,7 @@ export default function Home() {
 
           <p className="note fine">
             Prefer to do it by hand, or want the single-tenant hosted mode on Vercel? The{" "}
-            <a href={`${REPO}#get-started`} target="_blank" rel="noreferrer">
+            <a href={`${REPO}#install`} target="_blank" rel="noreferrer">
               README
             </a>{" "}
             has the full manual walkthrough and the permissions table.


### PR DESCRIPTION
## What changed

The README's Get started section documented both interfaces, but the MCP path started with "do the CLI setup first", so it read as an afterthought of the CLI install. This restructures it into an **Install** section with two clearly separated ways to install Liam:

- **Step 0** (unchanged): create a LinkedIn developer app.
- **Step 1** (new, shared): clone, build, write `~/.liads/config.json`, and run `auth login`. Both paths need this, so it is stated once instead of being folded into the CLI path.
- **Option 1: install as an MCP server.** Register with Claude Code, Claude Desktop, Cursor, or any MCP client, plus the optional hosted-on-Vercel mode.
- **Option 2: install the terminal CLI.** `pnpm link --global` for the `liam` command, plus a sensible first session.

MCP is listed first since it is the primary interface. The one-prompt assisted setup and everything after it are untouched.

Also updates the landing page's README link (`apps/web/app/page.tsx`) from `#get-started` to the new `#install` anchor so it doesn't dead-end at the top of the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)