### PR TITLE
Hosted MCP: bring your own credentials (multi-tenant)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ pnpm + TypeScript monorepo:
 - `packages/mcp` — MCP server. `src/tools.ts` registers all tools and is shared by the
   stdio entry (`src/index.ts`) and the hosted Vercel route. Add tools in `tools.ts`.
 - `packages/cli` — the `liam` CLI (commander) over the same core.
-- `apps/web` — Next.js app hosting the MCP over HTTP at `/api/mcp` (Vercel), gated by a
-  `MCP_AUTH_TOKEN` bearer.
+- `apps/web` — Next.js app hosting the MCP over HTTP at `/api/mcp` (Vercel). Two tenants:
+  the env-credential tenant gated by a `MCP_AUTH_TOKEN` bearer, and bring-your-own
+  credentials callers who send `X-Liads-*` headers (client id/secret + refresh token,
+  optional account id/version) that the route activates per request via
+  `withRequestCredentials` (core/config.ts, AsyncLocalStorage).
 
 Data flow: every tool/command builds a client via `createLiads()` (core/client.ts), which
 loads config + an auto-refreshing token provider, then calls a resource module. Resource
@@ -29,7 +32,9 @@ modules are thin typed wrappers over `LinkedInClient.request()`.
   change a field there first, then thread it through the resource module.
 - **Secrets never enter the repo.** Local credentials live in `~/.liads/`
   (`config.json` + `credentials.json`, mode 0600). Hosted credentials are `LIADS_*` env
-  vars on Vercel. The config layer (core/config.ts) resolves env first, then files.
+  vars on Vercel, or per-request `X-Liads-*` headers for bring-your-own-credentials
+  callers. The config layer (core/config.ts) resolves request context first, then env,
+  then files. Never log header credentials.
 - **Internal names are frozen.** The package scope `@liads/*`, the `~/.liads` dir, and the
   `LIADS_*` env prefix are intentionally NOT renamed to "liam" (renaming breaks stored
   creds and the deployed Vercel env). The brand "Liam" is visible-surface only.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ There are two ways to install Liam:
 
 1. **[As an MCP server](#option-1-install-as-an-mcp-server)**, registered with Claude
    Code, Claude Desktop, Cursor, or any MCP client, so you create campaigns by talking
-   to your assistant.
+   to your assistant. Run it locally, or skip the always-on install entirely and
+   [connect to the hosted endpoint with your own credentials](#hosted-mcp-connect-with-your-own-credentials-nothing-to-deploy).
 2. **[As a terminal CLI](#option-2-install-the-terminal-cli)**, a global `liam` command
    for running everything from your terminal, scripts, or cron.
 
@@ -165,26 +166,86 @@ claude mcp add liam -- node /abs/path/liam/packages/mcp/dist/index.js
 Ask for something read-only to confirm it works: "List my ad accounts" or "How did my
 account do in the last 30 days?"
 
-**Hosted on Vercel (optional, single-tenant).** Run the MCP server in the cloud so it
-works from clients that can't spawn local processes:
+#### Hosted MCP: connect with your own credentials, nothing to deploy
+
+The hosted MCP server at
+
+```
+https://liam-stan-defaultcoms-projects.vercel.app/api/mcp
+```
+
+is **multi-tenant, bring-your-own-credentials**: you pass your LinkedIn developer app's
+details as request headers, and every call runs against *your* app and *your* ad account.
+The server holds no state for you: credentials are used in memory to call LinkedIn and
+never logged or persisted.
+
+| Header | Value | Required? |
+| --- | --- | --- |
+| `X-Liads-Client-Id` | your LinkedIn app's Client ID | Yes |
+| `X-Liads-Client-Secret` | your LinkedIn app's Client Secret | Yes |
+| `X-Liads-Refresh-Token` | a refresh token from your `auth login` (~365d) | Yes |
+| `X-Liads-Account-Id` | numeric ad account id used when a call omits one | No |
+| `X-Liads-Linkedin-Version` | API version pin (YYYYMM), defaults to the server's | No |
+
+Do step 0 and step 1 above once (the LinkedIn app and the local `auth login`; LinkedIn's
+OAuth consent has to happen in your browser, so the token mint is the one local step).
+Then print the ready-to-run connect command:
+
+```bash
+node packages/cli/dist/index.js auth export --mcp
+# claude mcp add --transport http liam https://liam-…vercel.app/api/mcp \
+#   --header "X-Liads-Client-Id: …" \
+#   --header "X-Liads-Client-Secret: …" \
+#   --header "X-Liads-Refresh-Token: …" \
+#   --header "X-Liads-Account-Id: …"
+```
+
+Any MCP client that supports custom headers works the same way (for clients without
+native HTTP transport: `npx mcp-remote <url> --header "X-Liads-Client-Id: …" …`).
+Verify with a read-only call ("list my ad accounts"), and from then on the connection is
+just a URL plus headers, usable from machines that never cloned this repo.
+
+Know the trade-off: your client secret and refresh token travel with every request to
+that server, so only point them at a deployment you trust, or self-host the identical
+endpoint (next section). The scopes they carry can manage ads but never activate them;
+the draft-only rule is enforced in the tool layer itself.
+
+Hosted limitations (all by design, they need local resources): `upload_audience_csv`
+reads a CSV path on the server, `audience_from_salesforce` needs your local `sf` CLI,
+competitor-ads scraping falls back to API-only metadata (no browser), and the change
+journal / lift tools need the local `~/.liads/changelog.jsonl`. Run those through the
+local MCP server or CLI.
+
+**Put a skill on top.** The clean split for teams: your MCP client's config holds the
+credentials (the headers above), and a small skill or system prompt holds your playbook:
+default ad account, naming conventions, standing exclusions, house rules like "audience
+expansion always off". The [`skills/`](./skills) folder in this repo is a working example;
+copy one, swap in your defaults, and your assistant drives the hosted tools with your
+rules. Credentials never belong in a skill file.
+
+#### Self-host the same endpoint on Vercel
+
+Run your own instance so credentials never touch shared infrastructure, and so you also
+get a private env-configured tenant:
 
 1. Get your env values locally: `node packages/cli/dist/index.js auth export`.
 2. Deploy `apps/web` to Vercel (set the project **Root Directory** to `apps/web`).
 3. In Vercel project settings, add the env vars from `.env.example`
    (`LIADS_CLIENT_ID`, `LIADS_CLIENT_SECRET`, `LIADS_REFRESH_TOKEN`, `LIADS_LINKEDIN_VERSION`,
-   and a strong `MCP_AUTH_TOKEN`).
+   and a strong `MCP_AUTH_TOKEN`). In Vercel's Deployment Protection settings, disable
+   Vercel Authentication for production (or add a protection-bypass secret); otherwise
+   MCP clients can't reach the endpoint.
 4. Your MCP endpoint is `https://<your-app>.vercel.app/api/mcp`. Connect with the secret
    in the header:
 
 ```bash
 claude mcp add --transport http liam https://<your-app>.vercel.app/api/mcp \
   --header "Authorization: Bearer <MCP_AUTH_TOKEN>"
-# or, for clients without native HTTP transport:
-npx mcp-remote https://<your-app>.vercel.app/api/mcp --header "Authorization: Bearer <MCP_AUTH_TOKEN>"
 ```
 
-The scraper engine for competitor ads needs a local browser, so it stays local-only; the
-hosted server uses the official Ad Library API engine.
+Requests carrying `MCP_AUTH_TOKEN` use the env credentials (your tenant). Requests
+carrying the `X-Liads-*` headers above use the caller's credentials instead, so one
+self-hosted instance can serve your whole team, each member on their own LinkedIn app.
 
 ### Option 2: install the terminal CLI
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ account do in the last 30 days?"
 The hosted MCP server at
 
 ```
-https://liam-stan-defaultcoms-projects.vercel.app/api/mcp
+https://liam-mcp.vercel.app/api/mcp
 ```
 
 is **multi-tenant, bring-your-own-credentials**: you pass your LinkedIn developer app's

--- a/apps/web/app/api/[transport]/route.ts
+++ b/apps/web/app/api/[transport]/route.ts
@@ -1,12 +1,21 @@
 import { createMcpHandler } from "mcp-handler";
+import { withRequestCredentials, type RequestCredentials } from "@liads/core";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import { registerTools } from "@liads/mcp/tools";
 
 /**
- * Hosted (single-tenant) MCP server. The MCP endpoint is /api/mcp (Streamable
- * HTTP). LinkedIn credentials come from env (LIADS_CLIENT_ID/SECRET +
- * LIADS_REFRESH_TOKEN) via @liads/core's config layer. Access is gated by a
- * shared secret so only you can drive your ad account.
+ * Hosted MCP server at /api/mcp (Streamable HTTP). Two ways in:
+ *
+ * 1. Bring your own credentials (multi-tenant): send your LinkedIn developer
+ *    app details as headers on every request — X-Liads-Client-Id,
+ *    X-Liads-Client-Secret, X-Liads-Refresh-Token, plus optional
+ *    X-Liads-Account-Id and X-Liads-Linkedin-Version. The request runs
+ *    entirely against YOUR app and ad account; no shared secret needed, since
+ *    the headers grant nothing beyond what the caller already owns.
+ *    Credentials are used in-memory only and never logged or persisted.
+ *
+ * 2. Env tenant (the deploy owner): no X-Liads headers. Credentials come from
+ *    LIADS_* env vars and access is gated by MCP_AUTH_TOKEN.
  */
 const mcpHandler = createMcpHandler(
   // The adapter's server is the same MCP SDK type; cast across the version boundary.
@@ -16,6 +25,21 @@ const mcpHandler = createMcpHandler(
   { basePath: "/api" },
 );
 
+/** Caller-supplied credentials, when the request carries all three required headers. */
+function headerCredentials(req: Request): RequestCredentials | null {
+  const clientId = req.headers.get("x-liads-client-id");
+  const clientSecret = req.headers.get("x-liads-client-secret");
+  const refreshToken = req.headers.get("x-liads-refresh-token");
+  if (!clientId || !clientSecret || !refreshToken) return null;
+  return {
+    clientId,
+    clientSecret,
+    refreshToken,
+    defaultAccountId: req.headers.get("x-liads-account-id") ?? undefined,
+    linkedinVersion: req.headers.get("x-liads-linkedin-version") ?? undefined,
+  };
+}
+
 function authorized(req: Request): boolean {
   const token = process.env.MCP_AUTH_TOKEN;
   if (!token) return true; // Unset = open. Always set MCP_AUTH_TOKEN in production.
@@ -24,11 +48,18 @@ function authorized(req: Request): boolean {
 }
 
 async function guard(req: Request): Promise<Response> {
+  const creds = headerCredentials(req);
+  if (creds) {
+    return withRequestCredentials(creds, () => mcpHandler(req));
+  }
   if (!authorized(req)) {
-    return new Response(JSON.stringify({ error: "unauthorized" }), {
-      status: 401,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({
+        error: "unauthorized",
+        hint: "Send Authorization: Bearer <MCP_AUTH_TOKEN>, or bring your own LinkedIn app via X-Liads-Client-Id / X-Liads-Client-Secret / X-Liads-Refresh-Token headers (see the README).",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    );
   }
   return mcpHandler(req);
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,5 @@
 import { CopyButton } from "./CopyButton";
-import { CLI_SETUP_PROMPT, MCP_SETUP_PROMPT } from "./setupPrompt";
+import { CLI_SETUP_PROMPT, HOSTED_MCP_SETUP_PROMPT, MCP_SETUP_PROMPT } from "./setupPrompt";
 
 const REPO = "https://github.com/stan-default/liam";
 
@@ -26,7 +26,11 @@ const FAQ: Array<{ q: string; a: string }> = [
   },
   {
     q: "Where do my credentials live?",
-    a: "In a ~/.liads folder on your own machine, with file permissions locked to your user. Tokens go to LinkedIn's API and nowhere else. If you deploy the optional hosted mode, the credentials live in your own Vercel project's environment variables.",
+    a: "In a ~/.liads folder on your own machine, with file permissions locked to your user. Tokens go to LinkedIn's API and nowhere else. If you self-host the hosted mode, the credentials live in your own Vercel project's environment variables. If you connect to the shared hosted endpoint, they live in your MCP client's config as headers and ride along on each call; they are used in memory only and never stored on the server, but self-host if you would rather they never leave your infrastructure.",
+  },
+  {
+    q: "Can I use it without installing anything?",
+    a: "Almost. The hosted MCP endpoint lets any MCP client that supports custom headers connect with your own LinkedIn app credentials, so there is nothing to deploy or keep running. You still do one short local run to mint your refresh token (LinkedIn's OAuth consent has to happen in your browser); after that, the connection is just a URL plus headers. A skill or system prompt with your account defaults sits on top and the hosted tools do the rest.",
   },
   {
     q: "What does it cost?",
@@ -172,14 +176,33 @@ export default function Home() {
                 </pre>
               </div>
             </div>
+            <div className="col">
+              <h3>Use the hosted MCP</h3>
+              <p className="note">
+                Connect to the hosted endpoint with your own LinkedIn app credentials as
+                headers. Every call runs against your ad account; nothing to deploy or keep
+                running.
+              </p>
+              <div className="promptcard">
+                <div className="prompthead">
+                  <span>setup prompt · paste into claude code</span>
+                  <CopyButton text={HOSTED_MCP_SETUP_PROMPT} />
+                </div>
+                <pre className="code promptbox" tabIndex={0}>
+                  {HOSTED_MCP_SETUP_PROMPT}
+                </pre>
+              </div>
+            </div>
           </div>
 
           <p className="note fine">
-            Prefer to do it by hand, or want the single-tenant hosted mode on Vercel? The{" "}
+            Prefer to do it by hand, or want to self-host the hosted mode on your own Vercel
+            account? The{" "}
             <a href={`${REPO}#install`} target="_blank" rel="noreferrer">
               README
             </a>{" "}
-            has the full manual walkthrough and the permissions table.
+            has the full manual walkthrough, the hosted header reference, and the permissions
+            table.
           </p>
         </section>
 

--- a/apps/web/app/setupPrompt.ts
+++ b/apps/web/app/setupPrompt.ts
@@ -48,7 +48,7 @@ export const CLI_SETUP_PROMPT = `${INTRO}
 
 export const HOSTED_MCP_SETUP_PROMPT = `You are helping me connect to the hosted MCP endpoint of Liam, an
 open-source LinkedIn Ads Manager (https://github.com/stan-default/liam), at
-https://liam-stan-defaultcoms-projects.vercel.app/api/mcp. I bring my own
+https://liam-mcp.vercel.app/api/mcp. I bring my own
 LinkedIn developer app credentials as request headers, so every call runs
 against my own LinkedIn ad account, and everything Liam creates is a draft
 that spends nothing until I activate it myself in Campaign Manager.

--- a/apps/web/app/setupPrompt.ts
+++ b/apps/web/app/setupPrompt.ts
@@ -46,6 +46,39 @@ export const CLI_SETUP_PROMPT = `${INTRO}
 8. Show me a first session: "liam report summary -p last_30_days" and
    "liam targeting search titles" with a title I care about.${OUTRO}`;
 
+export const HOSTED_MCP_SETUP_PROMPT = `You are helping me connect to the hosted MCP endpoint of Liam, an
+open-source LinkedIn Ads Manager (https://github.com/stan-default/liam), at
+https://liam-stan-defaultcoms-projects.vercel.app/api/mcp. I bring my own
+LinkedIn developer app credentials as request headers, so every call runs
+against my own LinkedIn ad account, and everything Liam creates is a draft
+that spends nothing until I activate it myself in Campaign Manager.
+
+Work one step at a time, run commands for me where you can, and wait for my
+confirmation before moving on.
+
+1. Help me create a LinkedIn developer app at
+   https://www.linkedin.com/developers/apps (it must be associated with my
+   company's LinkedIn Page). On the Products tab request "Advertising API";
+   on the Auth tab add http://localhost:53682/callback as a redirect URL and
+   show me where the Client ID and Client Secret live.
+2. Mint my refresh token, the one step that runs locally: clone
+   https://github.com/stan-default/liam, run "pnpm install" and "pnpm -r build",
+   write my clientId and clientSecret into ~/.liads/config.json, then run
+   "node packages/cli/dist/index.js auth login" and approve in the browser.
+3. Run "node packages/cli/dist/index.js auth export --mcp". It prints the
+   exact "claude mcp add" command with my credentials as X-Liads headers.
+   Run that command for me (or show me where to paste the headers in my MCP
+   client's config if I am not on Claude Code).
+4. Confirm the liam tools load and show me one read-only call working, for
+   example list_ad_accounts. If my default account is missing, add an
+   "X-Liads-Account-Id" header with my ad account id.
+
+Remind me that my credentials travel with every call to that server, and that
+I can self-host the same endpoint on my own Vercel account if I prefer
+(the README has the steps).
+
+If a step fails, show me the exact error and fix it with me before moving on.`;
+
 export const MCP_SETUP_PROMPT = `You are helping me connect Liam, an open-source LinkedIn Ads Manager
 (https://github.com/stan-default/liam), to Claude as an MCP server. Everything
 it creates on LinkedIn is a draft, so nothing spends money until I activate it

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,9 @@ import {
 const program = new Command();
 program.name("liam").description("Liam, an ad manager for LinkedIn (CLI)").version("0.1.0");
 
+/** The public hosted MCP endpoint (see README "Hosted MCP" section). */
+const HOSTED_MCP_URL = "https://liam-stan-defaultcoms-projects.vercel.app/api/mcp";
+
 const auth = program.command("auth").description("Authentication");
 auth
   .command("login")
@@ -46,9 +49,30 @@ auth
 
 auth
   .command("export")
-  .description("Print env vars for the hosted (Vercel) MCP server")
-  .action(async () => {
+  .description("Print env vars for a self-hosted (Vercel) MCP server, or --mcp for a hosted connect command")
+  .option(
+    "--mcp [url]",
+    "Print the `claude mcp add` command that connects your credentials to a hosted Liam MCP endpoint",
+  )
+  .action(async (opts: { mcp?: string | boolean }) => {
     const env = await exportHostedEnv();
+    if (opts.mcp) {
+      const url = typeof opts.mcp === "string" ? opts.mcp : HOSTED_MCP_URL;
+      const { loadConfig } = await import("@liads/core");
+      const config = await loadConfig();
+      const headers = [
+        `--header "X-Liads-Client-Id: ${env.LIADS_CLIENT_ID}"`,
+        `--header "X-Liads-Client-Secret: ${env.LIADS_CLIENT_SECRET}"`,
+        `--header "X-Liads-Refresh-Token: ${env.LIADS_REFRESH_TOKEN}"`,
+      ];
+      if (config.defaultAccountId) headers.push(`--header "X-Liads-Account-Id: ${config.defaultAccountId}"`);
+      if (env.LIADS_LINKEDIN_VERSION) headers.push(`--header "X-Liads-Linkedin-Version: ${env.LIADS_LINKEDIN_VERSION}"`);
+      console.log(["claude mcp add --transport http liam", url, ...headers].join(" \\\n  "));
+      console.warn(
+        "! This command carries your app secret and refresh token. Your credentials ride along on every call to that server, so only point it at a deployment you trust, or self-host (see the README).",
+      );
+      return;
+    }
     for (const [k, v] of Object.entries(env)) if (v) console.log(`${k}=${v}`);
     console.warn("! Treat these as secrets. Paste into Vercel project env, do not commit.");
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program.name("liam").description("Liam, an ad manager for LinkedIn (CLI)").version("0.1.0");
 
 /** The public hosted MCP endpoint (see README "Hosted MCP" section). */
-const HOSTED_MCP_URL = "https://liam-stan-defaultcoms-projects.vercel.app/api/mcp";
+const HOSTED_MCP_URL = "https://liam-mcp.vercel.app/api/mcp";
 
 const auth = program.command("auth").description("Authentication");
 auth

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "./config.js";
+import { activeRequestCredentials, loadConfig } from "./config.js";
 import { LinkedInClient, type MutationHook, type TokenProvider } from "./http.js";
 import { createTokenProvider } from "./auth.js";
 import { recordMutation } from "./changelog.js";
@@ -17,9 +17,10 @@ export async function createLiads(): Promise<Liads> {
   const config = await loadConfig();
   const getToken = await createTokenProvider();
   // Auto-journal every change to the local changelog for later lift comparison.
-  // Disabled on hosted deploys (read-only FS, identified by LIADS_REFRESH_TOKEN)
-  // and whenever LIADS_NO_CHANGELOG is set.
-  const journaling = !process.env.LIADS_REFRESH_TOKEN && !process.env.LIADS_NO_CHANGELOG;
+  // Disabled on hosted deploys (read-only FS: LIADS_REFRESH_TOKEN env or
+  // per-request header credentials) and whenever LIADS_NO_CHANGELOG is set.
+  const journaling =
+    !activeRequestCredentials() && !process.env.LIADS_REFRESH_TOKEN && !process.env.LIADS_NO_CHANGELOG;
   const onMutation: MutationHook | undefined = journaling ? recordMutation : undefined;
   const client = new LinkedInClient(config, getToken, onMutation);
   return { client, getToken };

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 /** Directory holding app credentials + OAuth tokens for local use. Never in the repo. */
 export const LIADS_DIR = join(homedir(), ".liads");
@@ -35,10 +36,47 @@ export interface StoredCredentials {
 }
 
 /**
- * Loads app config. Prefers environment variables (hosted / Vercel), falls back
- * to ~/.liads/config.json (local CLI and self-host).
+ * Per-request credentials for the hosted multi-tenant path: a caller brings
+ * their own LinkedIn app + refresh token in request headers, and the HTTP
+ * handler runs the request inside `withRequestCredentials`. Everything below
+ * (loadConfig, resolveCredentialStore) checks this context first, so the same
+ * tool code serves the env-configured tenant and header-credentialed callers.
+ */
+export interface RequestCredentials {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  linkedinVersion?: string;
+  defaultAccountId?: string;
+}
+
+const requestCredentials = new AsyncLocalStorage<RequestCredentials>();
+
+/** Runs fn with the given caller credentials active for every nested call. */
+export function withRequestCredentials<T>(creds: RequestCredentials, fn: () => T): T {
+  return requestCredentials.run(creds, fn);
+}
+
+/** The caller credentials active for the current request, if any. */
+export function activeRequestCredentials(): RequestCredentials | undefined {
+  return requestCredentials.getStore();
+}
+
+/**
+ * Loads app config. Prefers per-request credentials (hosted multi-tenant),
+ * then environment variables (hosted / Vercel single tenant), then
+ * ~/.liads/config.json (local CLI and self-host).
  */
 export async function loadConfig(): Promise<AppConfig> {
+  const reqCreds = activeRequestCredentials();
+  if (reqCreds) {
+    return {
+      clientId: reqCreds.clientId,
+      clientSecret: reqCreds.clientSecret,
+      linkedinVersion: reqCreds.linkedinVersion,
+      defaultAccountId: reqCreds.defaultAccountId,
+    };
+  }
   if (process.env.LIADS_CLIENT_ID && process.env.LIADS_CLIENT_SECRET) {
     return {
       clientId: process.env.LIADS_CLIENT_ID,
@@ -117,8 +155,44 @@ export class EnvCredentialStore implements CredentialStore {
   }
 }
 
-/** Picks the env store when a refresh token is provided, else the file store. */
+/**
+ * Store for header-credentialed callers. Access tokens derived from a caller's
+ * refresh token are cached in module memory (keyed by that refresh token) so
+ * repeat calls within a warm instance don't re-hit LinkedIn's token endpoint.
+ * Nothing is ever written to disk.
+ */
+const requestTokenCache = new Map<string, StoredCredentials>();
+const REQUEST_TOKEN_CACHE_MAX = 100;
+
+export class RequestCredentialStore implements CredentialStore {
+  constructor(private readonly refreshToken: string) {}
+  async load(): Promise<StoredCredentials | null> {
+    return (
+      requestTokenCache.get(this.refreshToken) ?? {
+        accessToken: "",
+        refreshToken: this.refreshToken,
+        expiresAt: 0,
+      }
+    );
+  }
+  async save(creds: StoredCredentials): Promise<void> {
+    if (requestTokenCache.size >= REQUEST_TOKEN_CACHE_MAX) {
+      const oldest = requestTokenCache.keys().next().value;
+      if (oldest !== undefined) requestTokenCache.delete(oldest);
+    }
+    requestTokenCache.set(this.refreshToken, creds);
+  }
+}
+
+/**
+ * Picks the store matching where credentials came from: per-request headers,
+ * then the env refresh token, else the local file.
+ */
 export function resolveCredentialStore(): CredentialStore {
+  const reqCreds = activeRequestCredentials();
+  if (reqCreds) {
+    return new RequestCredentialStore(reqCreds.refreshToken);
+  }
   if (process.env.LIADS_REFRESH_TOKEN) {
     return new EnvCredentialStore(process.env.LIADS_REFRESH_TOKEN);
   }


### PR DESCRIPTION
## What

Anyone can now use the hosted Liam MCP endpoint at `https://liam-mcp.vercel.app/api/mcp` with **their own** LinkedIn developer app. Callers pass their credentials as request headers and every call runs against their app and their ad account; Stan's env-credential tenant stays gated by `MCP_AUTH_TOKEN`.

| Header | Required |
| --- | --- |
| `X-Liads-Client-Id` | yes |
| `X-Liads-Client-Secret` | yes |
| `X-Liads-Refresh-Token` | yes |
| `X-Liads-Account-Id` | no (default account for calls that omit one) |
| `X-Liads-Linkedin-Version` | no |

## How

- **core**: `withRequestCredentials` / `activeRequestCredentials` (AsyncLocalStorage) in the config layer; `loadConfig` and `resolveCredentialStore` check request context first, then env, then `~/.liads`. Derived access tokens cache in memory keyed by refresh token (capped at 100). Change journaling is disabled for header-credentialed calls (read-only FS on Vercel).
- **web**: the route runs header-credentialed requests inside the request context and skips the bearer gate for them (the headers grant nothing beyond what the caller already owns); requests without headers keep the existing `MCP_AUTH_TOKEN` gate.
- **cli**: `liam auth export --mcp` prints the ready-to-run `claude mcp add --transport http` command with the caller's headers filled from their local login.
- **docs**: README hosted section rewritten (header table, one-time local token mint, hosted limitations, put-a-skill-on-top pattern, self-host walkthrough); landing page gets a third setup prompt ("Use the hosted MCP") and two FAQ updates.

## Reachability

The public custom domain `liam-mcp.vercel.app` already bypasses Vercel deployment protection (protection only gates auto-generated and preview URLs), so no Vercel settings change is needed. All docs point at that domain.

## Verified

- `withRequestCredentials` + `createLiads` against live LinkedIn with `HOME` pointed at an empty directory (no ambient config): listed 4 ad accounts; without the context it correctly fails.
- Real MCP client handshake against `next dev` with `X-Liads-*` headers: 24 tools, `list_ad_accounts` and `list_conversions` (default account from header) both succeed.
- Auth gate matrix with `MCP_AUTH_TOKEN` set: no auth 401, correct bearer 200, wrong bearer 401, X-Liads headers without bearer 200.
- `pnpm -r build` green across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)