### PR TITLE
Docs page and nav button mirroring the repo README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,10 @@ pnpm -r typecheck
 
 ## Layout
 
-- `packages/core` — LinkedIn REST client, OAuth, resource modules, audience hashing, Salesforce reader.
-- `packages/mcp` — MCP server. `src/tools.ts` registers tools; `src/index.ts` is the stdio entry.
-- `packages/cli` — the `liam` CLI.
-- `apps/web` — Next.js app hosting the MCP over HTTP (Vercel).
+- `packages/core`: LinkedIn REST client, OAuth, resource modules, audience hashing, Salesforce reader.
+- `packages/mcp`: MCP server. `src/tools.ts` registers tools; `src/index.ts` is the stdio entry.
+- `packages/cli`: the `liam` CLI.
+- `apps/web`: Next.js app hosting the MCP over HTTP (Vercel).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ All commands also work via `node packages/cli/dist/index.js <cmd>`.
 
 ```
 liam auth login                         # OAuth, stores tokens in ~/.liads
-liam auth export                        # print env vars for the hosted (Vercel) server
+liam auth export                        # print env vars for a self-hosted (Vercel) server
+liam auth export --mcp                  # print the hosted-MCP connect command with your headers
 liam accounts list                      # list accessible ad accounts
 liam targeting search <facet> <query>   # typeahead a facet for entity URNs
 liam targeting estimate <facet> <urns…> # audience size for one facet's URNs

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ handles today, roughly in the order a campaign comes together:
   ignores edits to a live ad's post)
 - "Did the new headline actually help?" (change journal + before/after lift)
 
-Liam resolves the details, does the work, and reports back the ids. Every capability is
-also a `liam` CLI command for scripted or batch use.
+Liam resolves the details and reports back the ids. Every capability is also a `liam`
+CLI command for scripted or batch use.
 
 ### Put it on a loop
 
-Liam has no scheduler of its own, and doesn't need one: the client you drive it from does.
+There is no scheduler in Liam. Use the one in whatever client you drive it from.
 Some loops that work well:
 
 - "Every Monday at 9am, pull last week's performance summary, compare it to the week
@@ -63,10 +63,10 @@ Some loops that work well:
 
 ## Packages
 
-- `@liads/core` — LinkedIn REST client, OAuth, resource modules, CSV + SHA256 hashing, Salesforce reader.
-- `@liads/mcp` — MCP server (stdio for local; reused by the hosted app). **Primary interface.**
-- `@liads/cli` — the `liam` CLI over the same core, for scripted batch runs.
-- `@liads/web` — Next.js app that hosts the MCP over HTTP on Vercel.
+- `@liads/core`: LinkedIn REST client, OAuth, resource modules, CSV + SHA256 hashing, Salesforce reader.
+- `@liads/mcp`: MCP server (stdio for local; reused by the hosted app). **Primary interface.**
+- `@liads/cli`: the `liam` CLI over the same core, for scripted batch runs.
+- `@liads/web`: Next.js app that hosts the MCP over HTTP on Vercel.
 
 ## How it works
 
@@ -98,8 +98,8 @@ There are two ways to install Liam:
    for running everything from your terminal, scripts, or cron.
 
 Both run against **your own LinkedIn developer app**, so your credentials and your ad
-account stay yours. Both share the same first two steps: create a LinkedIn app (step 0)
-and build + authenticate (step 1). After that, pick your path, or do both; they read the
+account stay yours. The first two steps are shared: create a LinkedIn app (step 0) and
+build + authenticate (step 1). After that, pick your path, or do both; they read the
 same `~/.liads` credentials.
 
 ### Step 0: create a LinkedIn app (once)
@@ -355,30 +355,30 @@ See [skills/README.md](./skills/README.md) for details and conventions.
 - **Accounts:** `list_ad_accounts`
 - **Targeting:** `list_targeting_facets`, `search_targeting` (typeahead a facet for entity URNs),
   `list_facet_entities`, `estimate_audience` (structured spec). Talk in plain language
-  ("VPs of demand gen at SaaS companies in the US") and Liam resolves the facets, estimates
-  reach, then builds the campaign.
+  ("VPs of demand gen at SaaS companies in the US") and Liam resolves the facets and
+  estimates reach before building the campaign.
 - **Audiences:** `upload_audience_csv` (auto-cleans the CSV: normalizes column names, drops
   non-matcher columns, hashes emails, converts company domains to website URLs; supports both
-  contact and company lists), `audience_from_salesforce` (SOQL → matched audience), `get_audience_status`
+  contact and company lists), `audience_from_salesforce` (SOQL to matched audience), `get_audience_status`
 - **Conversions:** `list_conversions` (select an existing insight-tag conversion to track).
   `create_campaign` and `launch_from_brief` accept `conversionIds` or `conversionName`, and
   fall back to `defaultConversionName` from config.
 - **Campaigns:** `create_campaign_group`, `create_campaign`, `create_text_ad`, `create_image_ad`;
-  `list_campaigns` (the account structure — campaign groups and their ad groups, **drafts
+  `list_campaigns` (the account structure: campaign groups and their ad groups, **drafts
   included**, unlike reporting which only shows entities with spend), `list_ads`, `delete_ad`
   (removes the creative and best-effort its Direct Sponsored Content post). LinkedIn's editor
   ignores post edits on a live ad, so to change copy you recreate: `delete_ad` + `create_image_ad`.
 - **Orchestrator:** `launch_from_brief` (audience + group + campaign + draft creatives in one call)
 - **Reporting:** `performance_summary` (account rollup + top/bottom + flags), `get_performance`
   (per-entity KPIs at any level), `performance_trend` (weekly/monthly with deltas). KPIs: CTR,
-  CPC, CPM, CPL, conversion rate, cost per conversion. Levels: campaign_group → campaign → creative.
-- **Competitor intel:** `inspect_competitor_ads` — read any company's ads from the LinkedIn Ad
+  CPC, CPM, CPL, conversion rate, cost per conversion. Levels: campaign_group, campaign, creative.
+- **Competitor intel:** `inspect_competitor_ads` reads any company's ads from the LinkedIn Ad
   Library (no ad-account access needed). The **official Ad Library API** (`GET /rest/adLibrary`,
-  requires the "LinkedIn Ad Library" product grant) returns structured metadata — advertiser, payer,
-  format, and for EU-served ads run dates, impression ranges, per-country split, and targeting facets —
+  requires the "LinkedIn Ad Library" product grant) returns structured metadata (advertiser, payer,
+  format, and for EU-served ads run dates, impression ranges, per-country split, and targeting facets)
   but no creative. A **Playwright scraper** of the public library supplies the ad copy/image. Engines
   (`engine`): `api` (metadata only, fast, works hosted), `scraper` (copy via browser, local, supports
-  company-id), and `auto` (default — API metadata + copy layered from each ad's detail page, falling
+  company-id), and `auto` (default: API metadata plus copy layered from each ad's detail page, falling
   back to the scraper if the API isn't provisioned). Search by `advertiser` name or `keyword` (the API
   has no company-id or date filter). CLI: `liam competitor ads`.
 - **Change journal & lift:** `log_ad_change` (record a change), `list_ad_changes`, `compute_lift`
@@ -435,8 +435,8 @@ Periods: `last_7_days`, `last_30_days`, `last_90_days`, `month_to_date`, `last_m
 Liam keeps an append-only journal of every change made to an ad entity so you can measure the
 **lift** of a change: how performance differed in the window before it versus after.
 
-- **Where it lives:** `~/.liads/changelog.jsonl` (one JSON object per line). It's a plain local
-  file — no database, no account, no setup. Override the path with `LIADS_CHANGELOG_PATH`.
+- **Where it lives:** `~/.liads/changelog.jsonl` (one JSON object per line). A plain local
+  file with nothing to set up. Override the path with `LIADS_CHANGELOG_PATH`.
 - **Auto-capture:** every create/update Liam makes to a campaign group, campaign, or creative is
   journaled automatically (captured at the one HTTP chokepoint, so it can't be forgotten).
 - **Manual entries:** log changes made outside Liam (e.g. in Campaign Manager), or attach a
@@ -447,9 +447,9 @@ Liam keeps an append-only journal of every change made to an ad entity so you ca
   after, reporting before/after KPIs and per-metric deltas (CTR, CPC, conversion rate,
   cost-per-conversion, …). Recent changes get a clamped, `partial` after-window.
 
-This is a **directional pre/post comparison, not a controlled experiment** — it's confounded by
-seasonality, the LinkedIn learning phase after an edit, and any concurrent budget change. Read the
-deltas as a signal, not proof. Set `LIADS_NO_CHANGELOG=1` to disable auto-capture; journaling is
+This is a **directional pre/post comparison, not a controlled experiment**. It is confounded by
+seasonality, the LinkedIn learning phase after an edit, and any concurrent budget change, so treat
+the deltas as a signal. Set `LIADS_NO_CHANGELOG=1` to disable auto-capture; journaling is
 also off on hosted deploys (read-only filesystem).
 
 ## Configuration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,26 +7,27 @@ creates drafts, and nothing spends until you activate it.
 
 ## Shipped
 
-- **Campaign creation** — campaign groups, campaigns, and draft creatives (text + single-image
+- **Campaign creation**: campaign groups, campaigns, and draft creatives (text + single-image
   sponsored content), with every required LinkedIn field handled.
-- **Smarter targeting** — natural language to LinkedIn facets (titles, seniority, industry,
+- **Smarter targeting**: natural language to LinkedIn facets (titles, seniority, industry,
   company size, skills), with live audience-size estimates.
-- **Audiences** — CSV upload with automatic cleaning (column-name normalization, drop
+- **Audiences**: CSV upload with automatic cleaning (column-name normalization, drop
   non-matcher columns, domains to website URLs), contact and company lists, plus
   build-an-audience-straight-from-Salesforce.
-- **Conversions** — select an existing insight-tag conversion (e.g. Meeting Booked) when
+- **Conversions**: select an existing insight-tag conversion (e.g. Meeting Booked) when
   creating a campaign; never creates conversions.
-- **Reporting and insights** — per-level performance (account, campaign group, campaign,
+- **Reporting and insights**: per-level performance (account, campaign group, campaign,
   creative), weekly/monthly trends with deltas, derived KPIs (CTR, CPC, CPM, CPL, conversion
   rate, cost per conversion), and heuristic flags.
-- **Competitor ad intelligence** — read any company's live and recent ads from the LinkedIn Ad
+- **Competitor ad intelligence**: read any company's live and recent ads from the LinkedIn Ad
   Library (no ad-account access needed). The official Ad Library API (`GET /rest/adLibrary`, verified
-  live) returns structured metadata — advertiser, payer, format, and for EU-served ads run dates,
-  impression ranges, per-country split, and targeting facets — but no creative; a Playwright scraper of
+  live) returns structured metadata (advertiser, payer, format, and for EU-served ads run dates,
+  impression ranges, per-country split, and targeting facets) but no creative; a Playwright scraper of
   the public library layers in the ad copy/image. Engines `api` / `scraper` / `auto` (default: API
   metadata + copy from each ad's detail page, scraper fallback if unprovisioned). Synthesize messaging
   themes and how the account is run from the result. CLI `competitor ads`, MCP `inspect_competitor_ads`.
-- **Delivery** — local CLI, local MCP server, and a single-tenant hosted MCP on Vercel.
+- **Delivery**: local CLI, local MCP server, and a hosted MCP on Vercel that accepts your own
+  LinkedIn app credentials as headers, so nothing needs deploying to use it.
 
 ## Planned
 

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,0 +1,678 @@
+import Link from "next/link";
+
+const REPO = "https://github.com/stan-default/liam";
+const HOSTED_URL = "https://liam-mcp.vercel.app/api/mcp";
+
+export const metadata = {
+  title: "Docs · Liam",
+  description:
+    "Everything in the repo README, on one page: LinkedIn app setup, local MCP, the hosted endpoint with your own credentials, CLI reference, tools, skills, and safety.",
+};
+
+const TOC: Array<{ href: string; label: string }> = [
+  { href: "#overview", label: "Overview" },
+  { href: "#linkedin-app", label: "Step 0: LinkedIn app" },
+  { href: "#build-auth", label: "Step 1: build + auth" },
+  { href: "#local-mcp", label: "Local MCP" },
+  { href: "#hosted-mcp", label: "Hosted MCP" },
+  { href: "#self-host", label: "Self-host" },
+  { href: "#cli", label: "CLI" },
+  { href: "#tools", label: "Tools" },
+  { href: "#cli-reference", label: "CLI reference" },
+  { href: "#skills", label: "Skills" },
+  { href: "#journal", label: "Change journal" },
+  { href: "#configuration", label: "Configuration" },
+  { href: "#salesforce", label: "Salesforce" },
+  { href: "#safety", label: "Safety" },
+];
+
+export default function Docs() {
+  return (
+    <div className="wrap docs">
+      <header className="topbar reveal d1">
+        <span>
+          <b>
+            <Link href="/" style={{ color: "inherit", textDecoration: "none", border: "none" }}>
+              LIAM
+            </Link>
+          </b>{" "}
+          · LINKEDIN ADS MANAGER
+        </span>
+        <nav className="topnav">
+          <a href="/docs" aria-current="page">
+            DOCS
+          </a>
+          <a href={REPO} target="_blank" rel="noreferrer">
+            GITHUB
+          </a>
+        </nav>
+      </header>
+
+      <main>
+        <header className="dochead">
+          <h1 className="docmark reveal d1">Docs</h1>
+          <p className="lede reveal d2">
+            Everything you need to run Liam: the LinkedIn app, the local MCP server, the{" "}
+            <em>hosted endpoint you can use with your own credentials</em>, the CLI, and the
+            playbook skills on top. This page mirrors the{" "}
+            <a href={`${REPO}#readme`} target="_blank" rel="noreferrer">
+              repo README
+            </a>
+            .
+          </p>
+          <nav className="toc reveal d3">
+            {TOC.map((t) => (
+              <a key={t.href} href={t.href}>
+                {t.label}
+              </a>
+            ))}
+          </nav>
+        </header>
+
+        <section id="overview" className="section">
+          <p className="kicker">Overview</p>
+          <h2>What Liam is.</h2>
+          <p>
+            Liam is an ad manager for LinkedIn. You describe the campaign in plain language and
+            Liam drafts the audience, the ad groups, and the ads, from Claude over MCP or from a
+            CLI. It covers creation, matched audiences (including building one straight from
+            Salesforce), conversion selection, performance reporting, competitor ad intelligence,
+            and a change journal with before and after lift.
+          </p>
+          <p>
+            Everything Liam creates is a <b>draft</b>. There is deliberately no activate tool or
+            command anywhere in the codebase, so nothing spends until you switch a campaign on
+            yourself in Campaign Manager.
+          </p>
+          <h3>Hierarchy mapping</h3>
+          <p>LinkedIn names its levels differently than Google or Meta.</p>
+          <div className="tblwrap">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Common term</th>
+                  <th>LinkedIn entity</th>
+                  <th>Holds</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Campaign</td>
+                  <td>Campaign Group</td>
+                  <td>status, total or shared budget</td>
+                </tr>
+                <tr>
+                  <td>Ad group</td>
+                  <td>Campaign</td>
+                  <td>targeting, budget, bid, schedule, format</td>
+                </tr>
+                <tr>
+                  <td>Ad</td>
+                  <td>Creative</td>
+                  <td>
+                    the rendered ad (<code>status: DRAFT</code>)
+                  </td>
+                </tr>
+                <tr>
+                  <td>Audience</td>
+                  <td>DMP Segment</td>
+                  <td>attached to a Campaign&apos;s targeting</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="linkedin-app" className="section">
+          <p className="kicker">Step 0 · once</p>
+          <h2>Create a LinkedIn app.</h2>
+          <p>
+            Liam runs against <em>your own LinkedIn developer app</em>, so your credentials and
+            your ad account stay yours.
+          </p>
+          <ol>
+            <li>
+              Create an app at{" "}
+              <a href="https://www.linkedin.com/developers/apps" target="_blank" rel="noreferrer">
+                linkedin.com/developers/apps
+              </a>
+              . It must be associated with your company&apos;s LinkedIn Page.
+            </li>
+            <li>On the Products tab, request access to the products below.</li>
+            <li>
+              On the Auth tab, add <code>http://localhost:53682/callback</code> as an authorized
+              redirect URL, and note your Client ID and Client Secret.
+            </li>
+            <li>
+              Once the Advertising API is approved, map your ad account under Products &gt;
+              Advertising API &gt; View Ad Accounts. Skip this and <code>accounts list</code>{" "}
+              comes back empty.
+            </li>
+          </ol>
+          <div className="tblwrap">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Product</th>
+                  <th>Needed for</th>
+                  <th>Required?</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Advertising API</td>
+                  <td>campaigns, ads, targeting, reporting, conversions</td>
+                  <td>Yes</td>
+                </tr>
+                <tr>
+                  <td>Audiences</td>
+                  <td>uploading CSV contact and company lists as matched audiences</td>
+                  <td>Only for audience upload</td>
+                </tr>
+                <tr>
+                  <td>LinkedIn Ad Library</td>
+                  <td>competitor ad metadata via the official API</td>
+                  <td>Optional (the browser scraper works without it)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <h3>OAuth scopes</h3>
+          <p>
+            <code>liam auth login</code> requests <code>rw_ads</code> (create and edit campaigns),{" "}
+            <code>r_ads_reporting</code> (reporting), <code>rw_conversions</code> (conversion
+            tracking), and <code>w_organization_social</code> (image ads create a post owned by
+            your LinkedIn Page). If you add a product or scope later, run <code>auth login</code>{" "}
+            again; a token refresh keeps only the scopes you originally granted.
+          </p>
+        </section>
+
+        <section id="build-auth" className="section">
+          <p className="kicker">Step 1 · once</p>
+          <h2>Build and authenticate.</h2>
+          <p>Requires git, Node.js 20 or newer, and pnpm.</p>
+          <pre className="code" tabIndex={0}>{`git clone https://github.com/stan-default/liam.git
+cd liam
+pnpm install && pnpm -r build
+
+# App credentials (alternatively set LIADS_CLIENT_ID / LIADS_CLIENT_SECRET env vars)
+mkdir -p ~/.liads
+echo '{ "clientId": "...", "clientSecret": "...", "linkedinVersion": "202605" }' > ~/.liads/config.json
+
+node packages/cli/dist/index.js auth login      # opens the browser; tokens land in ~/.liads
+node packages/cli/dist/index.js accounts list   # verify, then set defaultAccountId in config.json`}</pre>
+        </section>
+
+        <section id="local-mcp" className="section">
+          <p className="kicker">Option 1</p>
+          <h2>Install as a local MCP server.</h2>
+          <p>
+            Register the server with your MCP client; it reads the <code>~/.liads</code>{" "}
+            credentials from step 1.
+          </p>
+          <pre className="code" tabIndex={0}>{`# Claude Code
+claude mcp add liam -- node /abs/path/liam/packages/mcp/dist/index.js
+
+# Claude Desktop, Cursor, or any MCP client, in its MCP config JSON:
+{
+  "mcpServers": {
+    "liam": { "command": "node", "args": ["/abs/path/liam/packages/mcp/dist/index.js"] }
+  }
+}`}</pre>
+          <p>
+            Ask for something read-only to confirm it works: &quot;List my ad accounts&quot; or
+            &quot;How did my account do in the last 30 days?&quot;
+          </p>
+        </section>
+
+        <section id="hosted-mcp" className="section">
+          <p className="kicker">Option 1b · nothing to deploy</p>
+          <h2>Use the hosted MCP with your own credentials.</h2>
+          <p>The hosted MCP server at</p>
+          <pre className="code" tabIndex={0}>{HOSTED_URL}</pre>
+          <p>
+            is <b>multi-tenant, bring your own credentials</b>: you pass your LinkedIn developer
+            app&apos;s details as request headers, and every call runs against <em>your</em> app
+            and <em>your</em> ad account. The server holds no state for you. Credentials are used
+            in memory to call LinkedIn and never logged or persisted.
+          </p>
+          <div className="tblwrap">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Header</th>
+                  <th>Value</th>
+                  <th>Required?</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <code>X-Liads-Client-Id</code>
+                  </td>
+                  <td>your LinkedIn app&apos;s Client ID</td>
+                  <td>Yes</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>X-Liads-Client-Secret</code>
+                  </td>
+                  <td>your LinkedIn app&apos;s Client Secret</td>
+                  <td>Yes</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>X-Liads-Refresh-Token</code>
+                  </td>
+                  <td>a refresh token from your auth login (about 365 days)</td>
+                  <td>Yes</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>X-Liads-Account-Id</code>
+                  </td>
+                  <td>numeric ad account id used when a call omits one</td>
+                  <td>No</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>X-Liads-Linkedin-Version</code>
+                  </td>
+                  <td>API version pin (YYYYMM), defaults to the server&apos;s</td>
+                  <td>No</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p>
+            Do step 0 and step 1 above once. LinkedIn&apos;s OAuth consent has to happen in your
+            browser, so the token mint is the one local step. Then print the ready-to-run connect
+            command:
+          </p>
+          <pre className="code" tabIndex={0}>{`node packages/cli/dist/index.js auth export --mcp
+# claude mcp add --transport http liam ${HOSTED_URL} \\
+#   --header "X-Liads-Client-Id: ..." \\
+#   --header "X-Liads-Client-Secret: ..." \\
+#   --header "X-Liads-Refresh-Token: ..." \\
+#   --header "X-Liads-Account-Id: ..."`}</pre>
+          <p>
+            Any MCP client that supports custom headers works the same way (for clients without
+            native HTTP transport: <code>npx mcp-remote &lt;url&gt; --header ...</code>). Verify
+            with a read-only call (&quot;list my ad accounts&quot;), and from then on the
+            connection is just a URL plus headers, usable from machines that never cloned the
+            repo.
+          </p>
+          <p>
+            Know the trade-off: your client secret and refresh token travel with every request to
+            that server, so only point them at a deployment you trust, or self-host the identical
+            endpoint (next section). The scopes they carry can manage ads but never activate
+            them; the draft-only rule is enforced in the tool layer itself.
+          </p>
+          <h3>Hosted limitations</h3>
+          <p>
+            All by design, they need local resources: <code>upload_audience_csv</code> reads a CSV
+            path on the server, <code>audience_from_salesforce</code> needs your local{" "}
+            <code>sf</code> CLI, competitor-ads scraping falls back to API-only metadata (no
+            browser), and the change journal and lift tools need the local{" "}
+            <code>~/.liads/changelog.jsonl</code>. Run those through the local MCP server or the
+            CLI.
+          </p>
+          <h3>Put a skill on top</h3>
+          <p>
+            The clean split for teams: your MCP client&apos;s config holds the credentials (the
+            headers above), and a small skill or system prompt holds your playbook: default ad
+            account, naming conventions, standing exclusions, house rules like &quot;audience
+            expansion always off&quot;. The{" "}
+            <a href={`${REPO}/tree/main/skills`} target="_blank" rel="noreferrer">
+              skills folder
+            </a>{" "}
+            in the repo is a working example; copy one, swap in your defaults, and your assistant
+            drives the hosted tools with your rules. Credentials never belong in a skill file.
+          </p>
+        </section>
+
+        <section id="self-host" className="section">
+          <p className="kicker">Option 1c</p>
+          <h2>Self-host the same endpoint on Vercel.</h2>
+          <p>
+            Run your own instance so credentials never touch shared infrastructure, and so you
+            also get a private env-configured tenant.
+          </p>
+          <ol>
+            <li>
+              Get your env values locally: <code>node packages/cli/dist/index.js auth export</code>
+              .
+            </li>
+            <li>
+              Deploy <code>apps/web</code> to Vercel (set the project Root Directory to{" "}
+              <code>apps/web</code>).
+            </li>
+            <li>
+              In Vercel project settings, add the env vars from <code>.env.example</code>{" "}
+              (<code>LIADS_CLIENT_ID</code>, <code>LIADS_CLIENT_SECRET</code>,{" "}
+              <code>LIADS_REFRESH_TOKEN</code>, <code>LIADS_LINKEDIN_VERSION</code>, and a strong{" "}
+              <code>MCP_AUTH_TOKEN</code>). In Deployment Protection settings, disable Vercel
+              Authentication for production (or add a protection-bypass secret); otherwise MCP
+              clients can&apos;t reach the endpoint.
+            </li>
+            <li>
+              Your MCP endpoint is <code>https://&lt;your-app&gt;.vercel.app/api/mcp</code>.
+              Connect with the secret in the header.
+            </li>
+          </ol>
+          <pre className="code" tabIndex={0}>{`claude mcp add --transport http liam https://<your-app>.vercel.app/api/mcp \\
+  --header "Authorization: Bearer <MCP_AUTH_TOKEN>"`}</pre>
+          <p>
+            Requests carrying <code>MCP_AUTH_TOKEN</code> use the env credentials (your tenant).
+            Requests carrying the <code>X-Liads-*</code> headers use the caller&apos;s credentials
+            instead, so one self-hosted instance can serve your whole team, each member on their
+            own LinkedIn app.
+          </p>
+        </section>
+
+        <section id="cli" className="section">
+          <p className="kicker">Option 2</p>
+          <h2>Install the terminal CLI.</h2>
+          <p>
+            Step 1 already left a working CLI at <code>node packages/cli/dist/index.js</code>. To
+            get a global <code>liam</code> command instead of the long node path:
+          </p>
+          <pre className="code" tabIndex={0}>{`cd packages/cli && pnpm link --global
+liam accounts list
+
+# A sensible first session:
+liam targeting search titles "demand generation"   # resolve targeting URNs
+liam report summary -p last_30_days                # account rollup + flags
+liam launch --brief examples/brief.json            # creates DRAFTS only`}</pre>
+        </section>
+
+        <section id="tools" className="section">
+          <p className="kicker">Tools · MCP</p>
+          <h2>Every tool the server exposes.</h2>
+          <div className="tblwrap">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Area</th>
+                  <th>Tools</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Accounts</td>
+                  <td>
+                    <code>list_ad_accounts</code>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Targeting</td>
+                  <td>
+                    <code>list_targeting_facets</code>, <code>search_targeting</code> (typeahead a
+                    facet for entity URNs), <code>list_facet_entities</code>,{" "}
+                    <code>estimate_audience</code>. Talk in plain language and Liam resolves the
+                    facets, estimates reach, then builds the campaign.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Audiences</td>
+                  <td>
+                    <code>upload_audience_csv</code> (auto-cleans the CSV: normalizes columns,
+                    hashes emails, converts company domains to URLs; contact and company lists),{" "}
+                    <code>audience_from_salesforce</code> (SOQL to matched audience),{" "}
+                    <code>get_audience_status</code>
+                  </td>
+                </tr>
+                <tr>
+                  <td>Conversions</td>
+                  <td>
+                    <code>list_conversions</code>. Campaign creation accepts{" "}
+                    <code>conversionIds</code> or <code>conversionName</code>, falling back to the
+                    config default.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Campaigns</td>
+                  <td>
+                    <code>create_campaign_group</code>, <code>create_campaign</code>,{" "}
+                    <code>create_text_ad</code>, <code>create_image_ad</code>,{" "}
+                    <code>list_campaigns</code> (drafts included, unlike reporting),{" "}
+                    <code>list_ads</code>, <code>delete_ad</code>. LinkedIn ignores post edits on
+                    a live ad, so to change copy you recreate: delete plus create.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Orchestrator</td>
+                  <td>
+                    <code>launch_from_brief</code> (audience + group + campaign + draft creatives
+                    in one call)
+                  </td>
+                </tr>
+                <tr>
+                  <td>Reporting</td>
+                  <td>
+                    <code>performance_summary</code>, <code>get_performance</code>,{" "}
+                    <code>performance_trend</code>. KPIs: CTR, CPC, CPM, CPL, conversion rate,
+                    cost per conversion.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Competitor intel</td>
+                  <td>
+                    <code>inspect_competitor_ads</code>: read any company&apos;s ads from the
+                    LinkedIn Ad Library. Engines: <code>api</code> (metadata, works hosted),{" "}
+                    <code>scraper</code> (ad copy via local browser), <code>auto</code> (both).
+                  </td>
+                </tr>
+                <tr>
+                  <td>Change journal</td>
+                  <td>
+                    <code>log_ad_change</code>, <code>list_ad_changes</code>,{" "}
+                    <code>compute_lift</code> (before vs after performance for each recorded
+                    change)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <h3>Targeting spec</h3>
+          <p>
+            Structured targeting uses short facet names mapped to entity URNs (resolve URNs with{" "}
+            <code>search_targeting</code>). URNs within a facet are ORed; facets are ANDed;
+            excluded facets are ORed.
+          </p>
+          <pre className="code" tabIndex={0}>{`{ "include": { "locations": ["urn:li:geo:103644278"], "seniorities": ["urn:li:seniority:7"] },
+  "exclude": { "industries": ["urn:li:industry:47"] } }`}</pre>
+        </section>
+
+        <section id="cli-reference" className="section">
+          <p className="kicker">CLI reference</p>
+          <h2>Every command, one screen.</h2>
+          <pre className="code" tabIndex={0}>{`liam auth login                         # OAuth, stores tokens in ~/.liads
+liam auth export                        # print env vars for a self-hosted (Vercel) server
+liam auth export --mcp                  # print the hosted-MCP connect command with your headers
+liam accounts list                      # list accessible ad accounts
+liam targeting search <facet> <query>   # typeahead a facet for entity URNs
+liam targeting estimate <facet> <urns>  # audience size for one facet's URNs
+liam audience upload -n <name> -f <csv> # clean + upload a CSV as a matched audience
+liam audience upload ... --dry-run      # preview the cleaned CSV, no upload
+liam audience from-salesforce -n <name> -q "<SOQL>"   # Salesforce query -> matched audience
+liam audience status <segmentId>        # matching status + resolved size
+liam conversions list                   # account conversions (pick one to track)
+liam campaigns list [--group <id>]      # campaign groups + ad groups, drafts included
+liam ad list <campaignId>               # ads in an ad group, drafts included
+liam ad delete <creativeId>             # delete an ad (creative + its DSC post)
+liam report summary [-p <period>]       # account rollup: totals, top performers, flags
+liam report perf <level> [--parent <id>] # per-entity KPI rows
+liam report trend <level> <id> [-b weekly|monthly]  # trend with deltas
+liam launch --brief <brief.json>        # audience + group + campaign + draft creatives
+liam competitor ads <advertiser>        # any company's ads from the public Ad Library
+liam changelog list [-t <type>] [-i <id>]           # recorded ad changes, newest first
+liam changelog add -t <type> -i <id> -f <field> --after <v>   # log a change made elsewhere
+liam lift <level> <id> [-w <days>]      # before vs after performance per recorded change
+
+# Periods: last_7_days, last_30_days, last_90_days, month_to_date, last_month.
+# --account defaults to defaultAccountId from config where applicable.`}</pre>
+        </section>
+
+        <section id="skills" className="section">
+          <p className="kicker">Skills</p>
+          <h2>Playbooks on top of Liam.</h2>
+          <p>
+            The{" "}
+            <a href={`${REPO}/tree/main/skills`} target="_blank" rel="noreferrer">
+              skills directory
+            </a>{" "}
+            ships ten portable agent skills that turn Liam&apos;s raw tools into opinionated
+            workflows. Each encodes a methodology: what to pull, how to judge it, significance
+            floors, caveats, and a fixed report format. Analysis and monitoring skills are
+            read-only; the operating skills create drafts only, after confirmation.
+          </p>
+          <ul>
+            <li>
+              <b>Analyze</b>: liam-spend, liam-performance, liam-leads, liam-competitors
+            </li>
+            <li>
+              <b>Monitor</b>: liam-weekly (fixed-format weekly digest), liam-health
+              (silent-unless-fire daily guardrails)
+            </li>
+            <li>
+              <b>Operate</b>: liam-launch, liam-experiments, liam-audiences, liam-account-audit
+            </li>
+          </ul>
+          <pre className="code" tabIndex={0}>{`./skills/install.sh   # symlinks them into ~/.claude/skills (Claude Code personal skills)`}</pre>
+        </section>
+
+        <section id="journal" className="section">
+          <p className="kicker">Change journal &amp; lift</p>
+          <h2>Every change is journaled, so lift is measurable.</h2>
+          <p>
+            Liam keeps an append-only journal of every change made to an ad entity, so you can
+            measure how performance differed in the window before a change versus after it.
+          </p>
+          <ul>
+            <li>
+              <b>Where it lives</b>: <code>~/.liads/changelog.jsonl</code>, a plain local file.
+              No database, no account, no setup.
+            </li>
+            <li>
+              <b>Auto-capture</b>: every create or update Liam makes is journaled at one HTTP
+              chokepoint, so it can&apos;t be forgotten.
+            </li>
+            <li>
+              <b>Manual entries</b>: log changes made in Campaign Manager, or attach a
+              hypothesis, with <code>liam changelog add</code> and a label naming the test.
+            </li>
+            <li>
+              <b>Lift</b>: <code>liam lift &lt;level&gt; &lt;id&gt;</code> compares the window
+              before each change (default 14 days) against the window after, with per-metric
+              deltas.
+            </li>
+          </ul>
+          <p>
+            This is a directional pre and post comparison, not a controlled experiment. It is
+            confounded by seasonality, the LinkedIn learning phase after an edit, and concurrent
+            budget changes. Read the deltas as a signal, not proof.
+          </p>
+        </section>
+
+        <section id="configuration" className="section">
+          <p className="kicker">Configuration</p>
+          <h2>One small config file.</h2>
+          <p>
+            Local config lives in <code>~/.liads/config.json</code> (mode 0600, never in the
+            repo). OAuth tokens are stored separately in <code>~/.liads/credentials.json</code>.
+            Hosted equivalents are the <code>LIADS_*</code> env vars plus{" "}
+            <code>MCP_AUTH_TOKEN</code>.
+          </p>
+          <div className="tblwrap">
+            <table className="tbl">
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <code>clientId</code>, <code>clientSecret</code>
+                  </td>
+                  <td>LinkedIn app credentials</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>linkedinVersion</code>
+                  </td>
+                  <td>
+                    pinned API version, e.g. <code>202605</code>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>defaultAccountId</code>
+                  </td>
+                  <td>ad account used when a command or brief omits one</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>defaultConversionName</code>
+                  </td>
+                  <td>conversion auto-selected for new campaigns when none is given</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>mcpAuthToken</code>
+                  </td>
+                  <td>bearer secret for a self-hosted MCP endpoint</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="salesforce" className="section">
+          <p className="kicker">Salesforce</p>
+          <h2>SOQL in, matched audience out.</h2>
+          <p>
+            Liam reads Salesforce by shelling out to the authenticated <code>sf</code> CLI, so it
+            reuses your existing login and needs no new credentials. Give it a SOQL query that
+            selects an email column and it becomes a matched audience, closing the loop from
+            &quot;accounts flagged in Salesforce&quot; to &quot;LinkedIn targeting&quot;.
+          </p>
+          <pre className="code" tabIndex={0}>{`liam audience from-salesforce -n "Q3 target accounts" \\
+  -q "SELECT Email FROM Contact WHERE Account.Target_List__c = true AND Email != null"`}</pre>
+        </section>
+
+        <section id="safety" className="section">
+          <p className="kicker">Safety</p>
+          <h2>The rules that don&apos;t bend.</h2>
+          <ul>
+            <li>
+              Every campaign and creative is created DRAFT or PAUSED. Activation is a separate,
+              explicit step you take in Campaign Manager.
+            </li>
+            <li>
+              Matched-audience matching takes up to 48 hours, and a campaign needs about 300
+              matched members to serve.
+            </li>
+            <li>
+              LinkedIn does not expose person-level ad-view data; cross-referencing is account and
+              segment level.
+            </li>
+            <li>
+              Secrets never enter the repo. Local: <code>~/.liads</code>. Hosted: your Vercel env
+              vars, or headers you control.
+            </li>
+          </ul>
+        </section>
+      </main>
+
+      <footer className="footer">
+        <span>Unofficial. Not affiliated with or endorsed by LinkedIn.</span>
+        <a href={REPO} target="_blank" rel="noreferrer">
+          github.com/stan-default/liam ↗
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -486,7 +486,7 @@ liam launch --brief examples/brief.json            # creates DRAFTS only`}</pre>
 
         <section id="cli-reference" className="section">
           <p className="kicker">CLI reference</p>
-          <h2>Every command, one screen.</h2>
+          <h2>The full CLI reference.</h2>
           <pre className="code" tabIndex={0}>{`liam auth login                         # OAuth, stores tokens in ~/.liads
 liam auth export                        # print env vars for a self-hosted (Vercel) server
 liam auth export --mcp                  # print the hosted-MCP connect command with your headers
@@ -571,7 +571,7 @@ liam lift <level> <id> [-w <days>]      # before vs after performance per record
           <p>
             This is a directional pre and post comparison, not a controlled experiment. It is
             confounded by seasonality, the LinkedIn learning phase after an edit, and concurrent
-            budget changes. Read the deltas as a signal, not proof.
+            budget changes, so treat the deltas as a signal.
           </p>
         </section>
 
@@ -632,7 +632,7 @@ liam lift <level> <id> [-w <days>]      # before vs after performance per record
 
         <section id="salesforce" className="section">
           <p className="kicker">Salesforce</p>
-          <h2>SOQL in, matched audience out.</h2>
+          <h2>From a Salesforce query to a matched audience.</h2>
           <p>
             Liam reads Salesforce by shelling out to the authenticated <code>sf</code> CLI, so it
             reuses your existing login and needs no new credentials. Give it a SOQL query that
@@ -645,7 +645,7 @@ liam lift <level> <id> [-w <days>]      # before vs after performance per record
 
         <section id="safety" className="section">
           <p className="kicker">Safety</p>
-          <h2>The rules that don&apos;t bend.</h2>
+          <h2>The safety rules.</h2>
           <ul>
             <li>
               Every campaign and creative is created DRAFT or PAUSED. Activation is a separate,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -81,20 +81,6 @@ body::after {
   color: var(--ink);
   font-weight: 600;
 }
-.status {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--amber);
-}
-.dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--amber);
-  box-shadow: 0 0 10px 2px rgba(255, 176, 0, 0.5);
-  animation: pulse 2.4s ease-in-out infinite;
-}
 
 /* hero */
 .hero {
@@ -545,15 +531,10 @@ body::after {
 @keyframes rise {
   to { opacity: 1; transform: none; }
 }
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
-}
 @media (max-width: 560px) {
   .topbar { font-size: 10px; letter-spacing: 0.12em; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .reveal { animation: none; opacity: 1; transform: none; }
-  .dot { animation: none; }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -350,6 +350,162 @@ body::after {
   color: var(--muted);
 }
 
+/* topbar nav */
+.topnav {
+  display: inline-flex;
+  gap: 22px;
+}
+.topnav a {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.18s;
+}
+.topnav a:hover,
+.topnav a[aria-current="page"] {
+  color: var(--amber);
+}
+
+/* docs */
+.docs .section {
+  padding: clamp(40px, 6vh, 64px) 0 0;
+  scroll-margin-top: 24px;
+}
+.docs header.dochead {
+  padding: clamp(40px, 8vh, 80px) 0 8px;
+}
+.docs .docmark {
+  font-family: var(--font-display), sans-serif;
+  font-weight: 900;
+  font-size: clamp(56px, 12vw, 120px);
+  line-height: 0.9;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--ink);
+}
+.docs .lede {
+  margin-top: 22px;
+  max-width: 64ch;
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--muted);
+}
+.docs .lede em {
+  font-style: normal;
+  color: var(--ink);
+}
+.docs .toc {
+  margin-top: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 28px;
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+}
+.docs .toc a {
+  color: var(--amber);
+  text-decoration: none;
+  border-bottom: 1px solid var(--amber-dim);
+  padding-bottom: 2px;
+  transition: border-color 0.18s;
+}
+.docs .toc a:hover {
+  border-color: var(--amber);
+}
+.docs p {
+  max-width: 72ch;
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+.docs p em,
+.docs li em {
+  font-style: normal;
+  color: var(--ink);
+}
+.docs p b,
+.docs li b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.docs a {
+  color: var(--amber);
+  text-decoration: none;
+  border-bottom: 1px solid var(--amber-dim);
+}
+.docs a:hover {
+  border-color: var(--amber);
+}
+.docs ul,
+.docs ol {
+  margin: 0 0 14px;
+  padding-left: 22px;
+}
+.docs li {
+  max-width: 70ch;
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.docs li::marker {
+  color: var(--amber);
+}
+.docs .code {
+  margin: 6px 0 18px;
+  padding-right: 18px;
+}
+.docs h3 {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink);
+  margin: 26px 0 10px;
+}
+.tblwrap {
+  overflow-x: auto;
+  margin: 6px 0 18px;
+}
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--amber-dim);
+  background: var(--panel);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.tbl th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--faint);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--amber-dim);
+}
+.tbl td {
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 176, 0, 0.05);
+  color: var(--muted);
+  vertical-align: top;
+}
+.tbl tr:last-child td {
+  border-bottom: none;
+}
+.tbl td:first-child {
+  color: var(--ink);
+  white-space: nowrap;
+}
+.tbl code {
+  font-family: inherit;
+  color: var(--ink);
+  background: var(--amber-dim);
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
 /* footer */
 .footer {
   margin-top: 56px;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -92,9 +92,17 @@ export default function Home() {
         <span>
           <b>LIAM</b> · LINKEDIN ADS MANAGER
         </span>
-        <span className="status">
-          <span className="dot" aria-hidden />
-          ON DUTY
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 22 }}>
+          <nav className="topnav">
+            <a href="/docs">DOCS</a>
+            <a href={REPO} target="_blank" rel="noreferrer">
+              GITHUB
+            </a>
+          </nav>
+          <span className="status">
+            <span className="dot" aria-hidden />
+            ON DUTY
+          </span>
         </span>
       </header>
 
@@ -105,13 +113,15 @@ export default function Home() {
           <p className="tagline reveal d2">
             The <em>LinkedIn Ads Manager</em> you talk to. Describe the campaign in plain language
             and Liam drafts the <em>audience</em>, the <em>ad groups</em>, and the <em>ads</em>.
-            Works from <em>Claude over MCP</em> or a <em>CLI</em>.
+            Works from <em>Claude over MCP</em> or a <em>CLI</em>, locally or through the{" "}
+            <em>hosted endpoint</em> with your own LinkedIn app.
           </p>
 
           <p className="heroLinks reveal d3">
             <a href="#get-started">Get started ↓</a>
             <a href="#use-cases">What it can do ↓</a>
             <a href="#faq">FAQ ↓</a>
+            <a href="/docs">Docs →</a>
             <a href={REPO} target="_blank" rel="noreferrer">
               GitHub ↗
             </a>
@@ -197,12 +207,12 @@ export default function Home() {
 
           <p className="note fine">
             Prefer to do it by hand, or want to self-host the hosted mode on your own Vercel
-            account? The{" "}
+            account? The <a href="/docs">docs</a> have the full manual walkthrough, the hosted
+            header reference, and the permissions table, mirrored from the{" "}
             <a href={`${REPO}#install`} target="_blank" rel="noreferrer">
               README
-            </a>{" "}
-            has the full manual walkthrough, the hosted header reference, and the permissions
-            table.
+            </a>
+            .
           </p>
         </section>
 
@@ -222,9 +232,12 @@ export default function Home() {
 
       <footer className="footer">
         <span>Unofficial. Not affiliated with or endorsed by LinkedIn.</span>
-        <a href={REPO} target="_blank" rel="noreferrer">
-          github.com/stan-default/liam ↗
-        </a>
+        <span style={{ display: "inline-flex", gap: 24 }}>
+          <a href="/docs">Docs</a>
+          <a href={REPO} target="_blank" rel="noreferrer">
+            github.com/stan-default/liam ↗
+          </a>
+        </span>
       </footer>
     </div>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -14,7 +14,7 @@ const FAQ: Array<{ q: string; a: string }> = [
   },
   {
     q: "How does it work?",
-    a: "A CLI and an MCP server sit on top of the same typed client for LinkedIn's Marketing API. You say what you want, your assistant calls the matching tools, and LinkedIn returns the ids. Every change Liam makes is journaled to a local file so you can measure the lift of any edit later.",
+    a: "A CLI and an MCP server sit on top of the same typed client for LinkedIn's Marketing API. You say what you want and your assistant calls the matching tools. Every change Liam makes is journaled to a local file so you can measure the lift of any edit later.",
   },
   {
     q: "How do I get started?",
@@ -22,15 +22,15 @@ const FAQ: Array<{ q: string; a: string }> = [
   },
   {
     q: "Do I need to be a developer?",
-    a: "You need a terminal with Claude Code installed, and the setup prompt does the rest. If you can paste a block of text and click approve in your browser, you can finish the setup.",
+    a: "No. You need a terminal with Claude Code installed, and the setup prompt does the rest. The hardest part is clicking approve in your browser when LinkedIn asks.",
   },
   {
     q: "Where do my credentials live?",
-    a: "In a ~/.liads folder on your own machine, with file permissions locked to your user. Tokens go to LinkedIn's API and nowhere else. If you self-host the hosted mode, the credentials live in your own Vercel project's environment variables. If you connect to the shared hosted endpoint, they live in your MCP client's config as headers and ride along on each call; they are used in memory only and never stored on the server, but self-host if you would rather they never leave your infrastructure.",
+    a: "In a ~/.liads folder on your own machine, with file permissions locked to your user. Tokens go to LinkedIn's API and nowhere else. Self-hosting the hosted mode puts them in your own Vercel project's environment variables. Connecting to the shared hosted endpoint puts them in your MCP client's config as headers, so they ride along on each call; the server uses them in memory and stores nothing. Self-host if you would rather they never leave your infrastructure.",
   },
   {
     q: "Can I use it without installing anything?",
-    a: "Almost. The hosted MCP endpoint lets any MCP client that supports custom headers connect with your own LinkedIn app credentials, so there is nothing to deploy or keep running. You still do one short local run to mint your refresh token (LinkedIn's OAuth consent has to happen in your browser); after that, the connection is just a URL plus headers. A skill or system prompt with your account defaults sits on top and the hosted tools do the rest.",
+    a: "Almost. The hosted MCP endpoint lets any MCP client that supports custom headers connect with your own LinkedIn app credentials, so there is nothing to deploy or keep running. You still do one short local run to mint your refresh token, since LinkedIn's OAuth consent has to happen in your browser. After that the connection is a URL plus headers, and a skill or system prompt holds your account defaults.",
   },
   {
     q: "What does it cost?",
@@ -38,7 +38,7 @@ const FAQ: Array<{ q: string; a: string }> = [
   },
   {
     q: "Does it only work with Claude?",
-    a: "It works with any MCP client: Claude Code, Claude Desktop, Cursor, and the rest. The CLI needs no assistant at all, so you can script it, pipe it, or put a weekly report in cron.",
+    a: "It works with any MCP client: Claude Code, Claude Desktop, Cursor, and the rest. The CLI needs no assistant at all. Put a weekly report in cron and it runs without one.",
   },
   {
     q: "Is this an official LinkedIn product?",
@@ -53,7 +53,7 @@ const USE_CASES: Array<{ q: string; note: string }> = [
   },
   {
     q: "Upload this CSV as a matched audience.",
-    note: "Cleans the columns, hashes emails, converts company domains to URLs.",
+    note: "Auto-cleans the columns and hashes emails; company domains become website URLs.",
   },
   {
     q: "Build an audience from Salesforce: every contact on a target account.",
@@ -92,18 +92,12 @@ export default function Home() {
         <span>
           <b>LIAM</b> · LINKEDIN ADS MANAGER
         </span>
-        <span style={{ display: "inline-flex", alignItems: "center", gap: 22 }}>
-          <nav className="topnav">
-            <a href="/docs">DOCS</a>
-            <a href={REPO} target="_blank" rel="noreferrer">
-              GITHUB
-            </a>
-          </nav>
-          <span className="status">
-            <span className="dot" aria-hidden />
-            ON DUTY
-          </span>
-        </span>
+        <nav className="topnav">
+          <a href="/docs">DOCS</a>
+          <a href={REPO} target="_blank" rel="noreferrer">
+            GITHUB
+          </a>
+        </nav>
       </header>
 
       <main>
@@ -148,7 +142,7 @@ export default function Home() {
           <p className="kicker">Get started</p>
           <h2>One prompt sets everything up.</h2>
           <p className="sub">
-            Pick how you want to use Liam, copy the prompt, and paste it into Claude Code. It
+            Pick how you want to use Liam and paste the matching prompt into Claude Code. It
             checks your machine, helps you create your own LinkedIn developer app, logs you in,
             and verifies the connection, one step at a time.
           </p>


### PR DESCRIPTION
## What

- **New `/docs` page** carrying the same information as the repo README, in the site's operator-console aesthetic: overview + hierarchy mapping, LinkedIn app setup (products and scopes tables), build + authenticate, local MCP install, the hosted bring-your-own-credentials endpoint (full `X-Liads-*` header table, `auth export --mcp`, limitations, skill-on-top pattern), self-hosting, CLI install, the MCP tools table, CLI reference, skills, change journal and lift, configuration, Salesforce, and safety. Anchor TOC at the top.
- **DOCS nav button** in the topbar on both pages (plus a GitHub link), a "Docs" hero link, and a docs link in the footer.
- **Homepage copy** updated for the hosted path: the tagline now says Liam works "locally or through the hosted endpoint with your own LinkedIn app", and the get-started fine print points at the docs.
- README CLI reference gains the `liam auth export --mcp` line.

## Verified

- `next build` green; `/docs` prerenders as a static page (3.4 kB).
- Screenshotted `next start` locally (home and docs, top and full page): nav, third setup card, TOC, tables, and code blocks all render in the existing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)