### PR TITLE
Add Vercel Analytics to the site and the hosted MCP server

### DIFF
--- a/apps/web/app/api/[transport]/route.ts
+++ b/apps/web/app/api/[transport]/route.ts
@@ -1,4 +1,6 @@
 import { createMcpHandler } from "mcp-handler";
+import { after } from "next/server";
+import { track } from "@vercel/analytics/server";
 import { withRequestCredentials, type RequestCredentials } from "@liads/core";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import { registerTools } from "@liads/mcp/tools";
@@ -47,7 +49,37 @@ function authorized(req: Request): boolean {
   return new URL(req.url).searchParams.get("key") === token;
 }
 
+/**
+ * Records each MCP request as a Vercel Analytics custom event: the JSON-RPC
+ * method, the tool name on tools/call, and whether the caller brought their
+ * own credentials. Never the credentials or arguments themselves. Analytics
+ * must never interfere with MCP traffic, so failures are swallowed.
+ */
+async function trackMcpRequest(req: Request): Promise<void> {
+  try {
+    if (req.method !== "POST") return;
+    const body: unknown = await req.clone().json();
+    const messages = Array.isArray(body) ? body : [body];
+    for (const msg of messages) {
+      const method = (msg as { method?: unknown })?.method;
+      if (typeof method !== "string") continue;
+      const tool =
+        method === "tools/call"
+          ? ((msg as { params?: { name?: unknown } }).params?.name as string | undefined)
+          : undefined;
+      await track("mcp_request", {
+        method,
+        tool: tool ?? null,
+        tenant: req.headers.get("x-liads-client-id") ? "byo" : "env",
+      });
+    }
+  } catch {
+    // ignore — analytics only
+  }
+}
+
 async function guard(req: Request): Promise<Response> {
+  after(() => trackMcpRequest(req));
   const creds = headerCredentials(req);
   if (creds) {
     return withRequestCredentials(creds, () => mcpHandler(req));

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Anton, IBM_Plex_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 const display = Anton({
@@ -29,7 +30,10 @@ export const viewport = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${display.variable} ${mono.variable}`}>
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@liads/core": "workspace:*",
     "@liads/mcp": "workspace:*",
+    "@vercel/analytics": "^2.0.1",
     "mcp-handler": "^1.0.1",
     "next": "^15.1.6",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@liads/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       mcp-handler:
         specifier: ^1.0.1
         version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -484,6 +487,35 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1316,6 +1348,11 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@vercel/analytics@2.0.1(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
Adds `@vercel/analytics` to `apps/web`, covering both surfaces:

**Website**: `<Analytics />` in the root layout tracks page views on `/` and `/docs`.

**MCP server**: the `/api/[transport]` route records each JSON-RPC request as an `mcp_request` custom event with three properties: the method (`initialize`, `tools/list`, `tools/call`, ...), the tool name when the method is `tools/call`, and whether the caller brought their own credentials (`byo`) or used the env tenant (`env`). Tracking runs in `next/server` `after()` so it adds no latency to MCP responses, and any parse or analytics failure is swallowed. Credentials and tool arguments are never sent.

Requires Web Analytics to be enabled on the Vercel project (Project → Analytics → Enable) for data to appear; custom events additionally require a Pro plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)