### PR TITLE
Harden hosted MCP auth: header-only, timing-safe, fail closed

### DIFF
--- a/apps/web/app/api/[transport]/route.ts
+++ b/apps/web/app/api/[transport]/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { createMcpHandler } from "mcp-handler";
 import { after } from "next/server";
 import { track } from "@vercel/analytics/server";
@@ -42,11 +43,20 @@ function headerCredentials(req: Request): RequestCredentials | null {
   };
 }
 
+/** Constant-time string comparison; never leaks how much of the token matched. */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
 function authorized(req: Request): boolean {
   const token = process.env.MCP_AUTH_TOKEN;
-  if (!token) return true; // Unset = open. Always set MCP_AUTH_TOKEN in production.
-  if (req.headers.get("authorization") === `Bearer ${token}`) return true;
-  return new URL(req.url).searchParams.get("key") === token;
+  // Unset token: fail closed in production, open only for local development.
+  if (!token) return process.env.NODE_ENV !== "production";
+  // Header only — a `?key=` query param would leak the token into request logs.
+  const auth = req.headers.get("authorization");
+  return auth !== null && safeEqual(auth, `Bearer ${token}`);
 }
 
 /**


### PR DESCRIPTION
Three tightenings to the hosted MCP endpoint's auth, from a security review of credential handling:

1. **Drop the `?key=` query-param fallback.** Tokens in URLs can end up in proxy and platform request logs. The bearer header is now the only way to present `MCP_AUTH_TOKEN`. (Nothing in the README or setup prompt documented the query param, so no caller-facing docs change.)
2. **Fail closed when `MCP_AUTH_TOKEN` is unset in production.** Previously an unset token left the env tenant open. Local development (`NODE_ENV !== "production"`) still works without a token.
3. **Timing-safe token comparison** via `crypto.timingSafeEqual` instead of string equality.

The bring-your-own-credentials path (`X-Liads-*` headers) is unchanged.

Verified: `tsc --noEmit` clean; the live endpoint already rejects missing/wrong bearers with 401, and this preserves that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)