### PR TITLE
Support multiple default conversions on new campaigns

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -23,6 +23,21 @@ export interface AppConfig {
   defaultAccountId?: string;
   /** Conversion name auto-selected for new campaigns when none is specified. */
   defaultConversionName?: string;
+  /**
+   * Conversion names auto-selected for new campaigns when none is specified.
+   * Takes precedence over defaultConversionName; every listed conversion is
+   * attached. Use resolveDefaultConversionNames() to read the effective list.
+   */
+  defaultConversionNames?: string[];
+}
+
+/**
+ * Effective list of default conversion names to attach to new campaigns:
+ * defaultConversionNames if set, else the single defaultConversionName, else [].
+ */
+export function resolveDefaultConversionNames(config: AppConfig): string[] {
+  if (config.defaultConversionNames?.length) return config.defaultConversionNames;
+  return config.defaultConversionName ? [config.defaultConversionName] : [];
 }
 
 export interface StoredCredentials {

--- a/packages/core/src/orchestrate.ts
+++ b/packages/core/src/orchestrate.ts
@@ -7,7 +7,7 @@ import { createTextAdCreative } from "./resources/creatives.js";
 import { createSponsoredImageDraft } from "./creative.js";
 import { estimateAudience, MIN_AUDIENCE_TO_SERVE, geoSegmentSpec, type TargetingSpec } from "./resources/targeting.js";
 import { resolveConversionIdByName } from "./resources/conversions.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, resolveDefaultConversionNames } from "./config.js";
 import { campaignManagerGroupLink, campaignManagerCampaignLink } from "./urns.js";
 
 export interface LaunchResult {
@@ -63,15 +63,20 @@ export async function launchFromBrief(
     // Estimate is best-effort; don't block the launch on it.
   }
 
-  // Resolve the conversion to track: explicit ids, else a name, else the config default.
+  // Resolve the conversion(s) to track: explicit ids, else an explicit name,
+  // else the config default list (defaultConversionNames).
   let conversionIds = input.conversionIds ?? [];
   if (conversionIds.length === 0) {
-    const name = input.conversionName ?? (await loadConfig()).defaultConversionName;
-    if (name) {
+    const names = input.conversionName
+      ? [input.conversionName]
+      : resolveDefaultConversionNames(await loadConfig());
+    const resolved: string[] = [];
+    for (const name of names) {
       const id = await resolveConversionIdByName(client, input.accountId, name);
-      if (id) conversionIds = [id];
-      else warnings.push(`Conversion "${name}" not found in this account; campaign created without it.`);
+      if (id) resolved.push(id);
+      else warnings.push(`Conversion "${name}" not found in this account; skipped.`);
     }
+    conversionIds = resolved;
   }
 
   // 2. Campaign group (DRAFT). runSchedule is required even for drafts.

--- a/packages/core/src/resources/campaigns.ts
+++ b/packages/core/src/resources/campaigns.ts
@@ -4,7 +4,7 @@ import type { CampaignInput } from "../schemas.js";
 import { sponsoredAccountUrn, campaignGroupUrn } from "../urns.js";
 import { buildTargetingCriteria, geoSegmentSpec, withDefaultExclusions } from "./targeting.js";
 import { associateCampaignWithConversion, resolveConversionIdByName } from "./conversions.js";
-import { loadConfig } from "../config.js";
+import { loadConfig, resolveDefaultConversionNames } from "../config.js";
 import type { CreatedEntity } from "./campaignGroups.js";
 
 /**
@@ -56,14 +56,16 @@ export async function createCampaign(
   if (!res.restliId) throw new Error("Campaign created but no id returned");
 
   // Conversions: use explicit ids if given, otherwise fall back to the account's
-  // default conversion (config.defaultConversionName) unless opted out.
+  // default conversion(s) (config.defaultConversionNames) unless opted out.
   let conversionIds = input.conversionIds ?? [];
   if (conversionIds.length === 0 && (input.applyDefaultConversion ?? true)) {
-    const name = (await loadConfig()).defaultConversionName;
-    if (name) {
+    const names = resolveDefaultConversionNames(await loadConfig());
+    const resolved: string[] = [];
+    for (const name of names) {
       const id = await resolveConversionIdByName(client, input.accountId, name);
-      if (id) conversionIds = [id];
+      if (id) resolved.push(id);
     }
+    conversionIds = resolved;
   }
   // Select existing conversions (e.g. an insight tag) for this campaign.
   for (const conversionId of conversionIds) {


### PR DESCRIPTION
## What

Lets an ad account attach more than one conversion by default when Liam creates a campaign, instead of only a single one. Motivated by adding a demo-form-submit conversion ("Vercel Form Submit") on top of the existing "Salesforce Opp (Zapier)" default so new campaigns track both without passing `conversionIds` on every call.

## How

- **`config.ts`**: add `defaultConversionNames?: string[]` to `AppConfig`, plus a `resolveDefaultConversionNames(config)` helper. It prefers the list, and falls back to the single `defaultConversionName` when the list is unset, so existing configs keep working unchanged.
- **`resources/campaigns.ts`** (`createCampaign`) and **`orchestrate.ts`** (`launchFromBrief`): when no explicit `conversionIds` are given, resolve every default conversion name to an id and attach all of them, instead of attaching only the first. `launchFromBrief` still honors an explicit `conversionName` override (single) when provided.

Backward compatible: an account with only `defaultConversionName` set behaves exactly as before (a single-element list).

## Config

To opt into multiple defaults, set in `~/.liads/config.json`:

```json
"defaultConversionNames": ["Salesforce Opp (Zapier)", "Vercel Form Submit"]
```

Verified at runtime that the two names resolve to their conversion ids in the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)