### PR TITLE
Add update_campaign: patch existing ad-set targeting and fields

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,10 @@ import {
   listCampaigns,
   listCreatives,
   deleteAd,
+  getCampaign,
+  updateCampaign,
+  adSegmentUrn,
+  MIN_AUDIENCE_TO_SERVE,
 } from "@liads/core";
 
 const program = new Command();
@@ -418,6 +422,83 @@ campaigns
     }
     const orphans = list.filter((c) => !groupName.has(c.campaignGroupId));
     for (const c of orphans) console.log(`? ${c.id}\t${c.status}\t${c.name} (group ${c.campaignGroupId})`);
+  });
+
+campaigns
+  .command("get <campaignId>")
+  .description("Show a campaign (ad group): status, name, and its current targeting")
+  .option("--account <accountId>", "ad account id (defaults to config)")
+  .action(async (campaignId, opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const c = (await getCampaign(liads.client, accountId, campaignId)) as Record<string, unknown>;
+    console.log(`${c.id ?? campaignId}\t${c.status ?? ""}\t${c.name ?? ""}`);
+    console.log("targetingCriteria:");
+    console.log(JSON.stringify(c.targetingCriteria ?? {}, null, 2));
+  });
+campaigns
+  .command("update <campaignId>")
+  .description("Update a campaign (ad group) in place. Previews by default; add --apply to send.")
+  .option("--account <accountId>", "ad account id (defaults to config)")
+  .option("--audience <urnOrId>", "matched audience to target (adSegment urn or bare id) — replaces targeting")
+  .option("--geo <urns...>", "geo urns to include alongside the audience")
+  .option("--targeting <json>", "structured targeting spec as JSON, e.g. '{\"include\":{...}}'")
+  .option("--no-default-exclusions", "do not merge the standing default exclusions into new targeting")
+  .option("--name <name>", "rename the campaign")
+  .option("--status <status>", "DRAFT | ACTIVE | PAUSED | ARCHIVED")
+  .option("--daily-budget <amount>", "daily budget amount, e.g. 100.00")
+  .option("--total-budget <amount>", "total budget amount")
+  .option("--bid <amount>", "bid (unit cost) amount")
+  .option("--currency <code>", "currency for budgets/bid (default USD)", "USD")
+  .option("--apply", "actually send the update (otherwise just preview the patch)")
+  .action(async (campaignId, opts) => {
+    const liads = await createLiads();
+    const accountId = opts.account ?? (await requireDefaultAccountId());
+    const money = (amount?: string) => (amount ? { amount, currencyCode: opts.currency } : undefined);
+
+    const targeting = opts.targeting ? JSON.parse(opts.targeting) : undefined;
+    const input = {
+      accountId,
+      campaignId,
+      audienceSegmentUrn: opts.audience ? adSegmentUrn(opts.audience) : undefined,
+      geoUrns: opts.geo,
+      targeting,
+      applyDefaultExclusions: opts.defaultExclusions !== false,
+      name: opts.name,
+      status: opts.status,
+      dailyBudget: money(opts.dailyBudget),
+      totalBudget: money(opts.totalBudget),
+      unitCost: money(opts.bid),
+      dryRun: !opts.apply,
+    };
+
+    // When targeting is being replaced with a derivable spec, estimate the reach
+    // so we catch the >=300 members-to-serve floor before (or as) we apply it.
+    let spec: { include: Record<string, string[]>; exclude?: Record<string, string[]> } | undefined;
+    if (targeting) spec = targeting;
+    else if (opts.audience) {
+      const include: Record<string, string[]> = { audienceMatchingSegments: [adSegmentUrn(opts.audience)] };
+      if (opts.geo?.length) include.locations = opts.geo;
+      spec = { include };
+    }
+    if (spec) {
+      try {
+        const est = await estimateAudience(liads.client, spec);
+        const flag = est.total < MIN_AUDIENCE_TO_SERVE ? `  [WARNING] below ${MIN_AUDIENCE_TO_SERVE}, will NOT serve (note: forecast reads 0 for dynamicSegments/retargeting audiences — verify real size in CM)` : "";
+        console.log(`Estimated audience: ${est.total} total (${est.active} active)${flag}`);
+      } catch (e) {
+        console.log(`(could not estimate audience: ${e instanceof Error ? e.message : e})`);
+      }
+    }
+
+    const res = await updateCampaign(liads.client, input as Parameters<typeof updateCampaign>[1]);
+    if (res.dryRun) {
+      console.log(`\nDRY RUN — nothing sent. Patch for campaign ${campaignId} (fields: ${res.updated.join(", ")}):`);
+      console.log(JSON.stringify(res.patch, null, 2));
+      console.log("\nRe-run with --apply to send this update.");
+    } else {
+      console.log(`Updated campaign ${res.id} (fields: ${res.updated.join(", ")}).`);
+    }
   });
 
 const ad = program.command("ad").description("Individual ads (creatives)");

--- a/packages/core/src/resources/campaigns.ts
+++ b/packages/core/src/resources/campaigns.ts
@@ -1,7 +1,7 @@
 import type { LinkedInClient } from "../http.js";
 import { searchAll } from "./search.js";
-import type { CampaignInput } from "../schemas.js";
-import { sponsoredAccountUrn, campaignGroupUrn } from "../urns.js";
+import type { CampaignInput, CampaignUpdateInput } from "../schemas.js";
+import { sponsoredAccountUrn, campaignGroupUrn, adSegmentUrn } from "../urns.js";
 import { buildTargetingCriteria, geoSegmentSpec, withDefaultExclusions } from "./targeting.js";
 import { associateCampaignWithConversion, resolveConversionIdByName } from "./conversions.js";
 import { loadConfig, resolveDefaultConversionNames } from "../config.js";
@@ -77,6 +77,81 @@ export async function createCampaign(
 export async function getCampaign(client: LinkedInClient, accountId: string, campaignId: string) {
   const res = await client.request({ path: `/adAccounts/${accountId}/adCampaigns/${campaignId}` });
   return res.data;
+}
+
+export interface CampaignUpdateResult {
+  id: string;
+  /** Names of the fields included in the patch. */
+  updated: string[];
+  /** The targetingCriteria that was set, when targeting was changed. */
+  targetingCriteria?: Record<string, unknown>;
+  /** True when dryRun: the patch was built and returned but NOT sent. */
+  dryRun?: boolean;
+  /** The full PARTIAL_UPDATE $set payload (handy for review on a dry run). */
+  patch?: Record<string, unknown>;
+}
+
+/**
+ * Patch an existing campaign ("ad group") in place via LinkedIn PARTIAL_UPDATE.
+ * Only the fields provided are changed. Targeting is replaced wholesale when any
+ * targeting form is supplied (structured spec, audienceSegmentUrn shorthand, or
+ * raw targetingCriteria) — built through the SAME helpers as createCampaign, so
+ * the standing default exclusions and the include/exclude tree stay identical.
+ * The Audience Expansion / Audience Network off-switches are campaign-create
+ * settings and are never re-enabled here. With dryRun the patch is returned but
+ * not sent, so callers can preview a change before touching a live campaign.
+ */
+export async function updateCampaign(
+  client: LinkedInClient,
+  input: CampaignUpdateInput,
+): Promise<CampaignUpdateResult> {
+  const patch: Record<string, unknown> = {};
+
+  const hasTargeting =
+    input.targetingCriteria !== undefined ||
+    input.targeting !== undefined ||
+    input.audienceSegmentUrn !== undefined ||
+    (input.geoUrns?.length ?? 0) > 0;
+
+  let targetingCriteria: Record<string, unknown> | undefined;
+  if (hasTargeting) {
+    const base =
+      input.targetingCriteria ??
+      buildTargetingCriteria(
+        input.targeting ??
+          geoSegmentSpec(
+            input.geoUrns,
+            input.audienceSegmentUrn ? adSegmentUrn(input.audienceSegmentUrn) : undefined,
+          ),
+      );
+    targetingCriteria =
+      (input.applyDefaultExclusions ?? true) ? withDefaultExclusions(base) : base;
+    patch.targetingCriteria = targetingCriteria;
+  }
+
+  if (input.name !== undefined) patch.name = input.name;
+  if (input.status !== undefined) patch.status = input.status;
+  if (input.dailyBudget !== undefined) patch.dailyBudget = input.dailyBudget;
+  if (input.totalBudget !== undefined) patch.totalBudget = input.totalBudget;
+  if (input.unitCost !== undefined) patch.unitCost = input.unitCost;
+  if (input.runSchedule !== undefined) patch.runSchedule = input.runSchedule;
+
+  const updated = Object.keys(patch);
+  if (updated.length === 0) {
+    throw new Error("Nothing to update: provide targeting and/or a field to change.");
+  }
+
+  if (input.dryRun) {
+    return { id: input.campaignId, updated, targetingCriteria, dryRun: true, patch };
+  }
+
+  await client.request({
+    method: "POST",
+    path: `/adAccounts/${input.accountId}/adCampaigns/${input.campaignId}`,
+    headers: { "X-RestLi-Method": "PARTIAL_UPDATE" },
+    body: { patch: { $set: patch } },
+  });
+  return { id: input.campaignId, updated, targetingCriteria };
 }
 
 /** Change a campaign's status (e.g. archive cleanup). */

--- a/packages/core/src/resources/targeting.ts
+++ b/packages/core/src/resources/targeting.ts
@@ -21,7 +21,8 @@ export const COMMON_FACETS: Record<string, string> = {
   skills: "urn:li:skill",
   employers: "urn:li:organization",
   employersPast: "urn:li:organization",
-  audienceMatchingSegments: "urn:li:adSegment",
+  audienceMatchingSegments: "urn:li:adSegment", // uploaded/matched lists (contact/company)
+  dynamicSegments: "urn:li:adSegment", // behavioral/retargeting audiences (ad engagers, site visitors, video viewers)
   interests: "urn:li:interest",
   degrees: "urn:li:degree",
   fieldsOfStudy: "urn:li:fieldOfStudy",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -91,6 +91,39 @@ export const CampaignInputSchema = z.object({
 });
 export type CampaignInput = z.infer<typeof CampaignInputSchema>;
 
+/**
+ * Patch an existing campaign ("ad group"). Every field is optional: only the
+ * ones provided are changed (LinkedIn PARTIAL_UPDATE). Targeting is replaced
+ * wholesale when any targeting form is given — pass a structured `targeting`
+ * spec, the `audienceSegmentUrn` (+ optional `geoUrns`) shorthand, or a raw
+ * `targetingCriteria`. Leave all three unset to keep the current targeting.
+ */
+export const CampaignUpdateSchema = z.object({
+  accountId: z.string(),
+  campaignId: z.string().describe("Numeric campaign (ad group) id to update"),
+  /** Raw targetingCriteria tree (replaces existing). Prefer `targeting`/`audienceSegmentUrn`. */
+  targetingCriteria: z.record(z.any()).optional(),
+  /** Structured targeting (facets + entity URNs). Replaces existing targeting. */
+  targeting: TargetingSpecSchema.optional(),
+  audienceSegmentUrn: z
+    .string()
+    .optional()
+    .describe("urn:li:adSegment:... (or bare id) matched audience to target — replaces existing targeting"),
+  geoUrns: z.array(z.string()).optional().describe("urn:li:geo:... locations to include alongside the audience"),
+  /** When replacing targeting, merge the standing default exclusions in. Set false to skip. */
+  applyDefaultExclusions: z.boolean().default(true),
+  /** Other patchable fields (each left unchanged when omitted). */
+  name: z.string().min(1).optional(),
+  status: z.enum(["DRAFT", "ACTIVE", "PAUSED", "ARCHIVED"]).optional(),
+  dailyBudget: MoneySchema.optional(),
+  totalBudget: MoneySchema.optional(),
+  unitCost: MoneySchema.optional().describe("Bid amount"),
+  runSchedule: RunScheduleSchema.optional(),
+  /** Build and return the patch WITHOUT sending it. Preview before touching a live campaign. */
+  dryRun: z.boolean().default(false),
+});
+export type CampaignUpdateInput = z.infer<typeof CampaignUpdateSchema>;
+
 export const TextAdCreativeSchema = z.object({
   accountId: z.string(),
   campaignId: z.string(),

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -17,6 +17,7 @@ import {
   SalesforceAudienceSchema,
   createCampaignGroup,
   createCampaign,
+  updateCampaign,
   createTextAdCreative,
   createSponsoredImageDraft,
   launchFromBrief,
@@ -29,6 +30,7 @@ import {
   TrendQuerySchema,
   CampaignGroupInputSchema,
   CampaignInputSchema,
+  CampaignUpdateSchema,
   TextAdCreativeSchema,
   SponsoredImageCreativeSchema,
   LaunchFromBriefSchema,
@@ -261,6 +263,20 @@ export function registerTools(server: McpServer): void {
       try {
         const liads = await createLiads();
         return ok(await createCampaign(liads.client, CampaignInputSchema.parse(args)));
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    "update_campaign",
+    "Update an existing campaign (the 'ad group') in place: change its targeting and/or name, status, budget, bid, schedule. Only the fields you pass change. Targeting is REPLACED when you pass any targeting form — a structured `targeting` spec, the `audienceSegmentUrn` (+ optional `geoUrns`) shorthand, or a raw `targetingCriteria`; default exclusions are re-applied unless applyDefaultExclusions=false. Audience Expansion / Audience Network stay off. Pass dryRun=true first to preview the patch before touching a live campaign.",
+    CampaignUpdateSchema.shape,
+    async (args) => {
+      try {
+        const liads = await createLiads();
+        return ok(await updateCampaign(liads.client, CampaignUpdateSchema.parse(args)));
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
## Why

Liam could create campaigns but never edit them. Changing an existing ad group's targeting (e.g. swapping it to a retargeting audience) had to be done by hand in Campaign Manager. This adds in-place updates end to end.

## What

- **core**: `updateCampaign()` via LinkedIn `PARTIAL_UPDATE`, reusing the same `buildTargetingCriteria` + `withDefaultExclusions` as create, so targeting and the standing default exclusions stay identical. Audience Expansion / Audience Network stay off. `dryRun` returns the built patch without sending.
- **core**: new `dynamicSegments` targeting facet for behavioral/retargeting audiences (ad engagers, site visitors, video viewers), alongside `audienceMatchingSegments` for uploaded contact/company lists. Using the wrong facet returns a hard 400 naming the expected facet.
- **mcp**: `update_campaign` tool.
- **cli**: `campaigns get <id>` (show current targeting) and `campaigns update <id>` (previews by default, `--apply` to send, runs a reach estimate against the 300-member serve floor).

## Notes / gotchas surfaced

- Retargeting audiences must use `dynamicSegments`, not `audienceMatchingSegments`.
- LinkedIn's `audienceCounts` forecast reads 0 for `dynamicSegments` audiences even when populated. Verify real size via the Campaign Manager audience "Last audience count", not the estimate. The CLI warning text calls this out.

## Verification

Built all packages. Used the new CLI to swap all 5 "Product - All Competitors" ad sets onto an engagement-retargeting audience (dry-run previewed, `--apply` sent, `campaigns get` confirmed the new targeting). Changes auto-journal to the changelog for later lift analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)